### PR TITLE
dracut-module-setup: Fix missing systemd/system.conf error

### DIFF
--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -973,21 +973,24 @@ kdump_install_random_seed() {
 
 kdump_install_systemd_conf() {
     # Kdump turns out to require longer default systemd mount timeout
-    # than 1st kernel(90s by default), we use default 300s for kdump.
-    if ! grep -q -r "^[[:space:]]*DefaultTimeoutStartSec=" "${initdir}/etc/systemd/system.conf"*; then
-        mkdir -p "${initdir}/etc/systemd/system.conf.d"
-        echo "[Manager]" > "${initdir}/etc/systemd/system.conf.d/kdump.conf"
-        echo "DefaultTimeoutStartSec=300s" >> "${initdir}/etc/systemd/system.conf.d/kdump.conf"
-    fi
+    # than 1st kernel(45s by default), we use default 300s for kdump.
+    mkdir -p "${initdir}/etc/systemd/system.conf.d"
+    cat > "${initdir}/etc/systemd/system.conf.d/99-kdump.conf" << EOF
+[Manager]
+DefaultTimeoutStartSec=300s
+EOF
+
 
     # Forward logs to console directly, and don't read Kmsg, this avoids
     # unneccessary memory consumption and make console output more useful.
     # Only do so for non fadump image.
     mkdir -p "${initdir}/etc/systemd/journald.conf.d"
-    echo "[Journal]" > "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "Storage=volatile" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ReadKMsg=no" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ForwardToConsole=yes" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
+    cat > "${initdir}/etc/systemd/journald.conf.d/99-kdump.conf" << EOF
+[Journal]
+Storage=volatile
+ReadKMsg=no
+ForwardToConsole=yes
+EOF
 }
 
 remove_cpu_online_rule() {


### PR DESCRIPTION
There is a bug report for RHEL10 about a grep error reading

  grep: /var/tmp/dracut.DiZuKp/initramfs/etc/systemd/system.conf*: No such file or directory

that shows up when rebuilding the initrd. This is caused by systemd v255 that allows installing the default systemd config files to /usr/lib/systemd instead of /etc/systemd [1][2] which is done for RHEL. So unless a user manually adds /etc/systemd/system.conf the file no longer exists.

However the test that requires the call to grep is somewhat wonky. IIUC the test is there so we don't overwrite a setting the user might have made. In my opinion this only makes sense as long as the timeout set is larger than what we would set. But this part of the logic is missing. So fix the error message by removing the test and add our config unconditionally.

While at it rename the created drop-ins to 99-kdump.conf to follow the recommended naming convention and to make sure that our value takes precedence.

Note: In case the test is still needed we can fall back to use 'systemd-analyse cat-config' that automatically considers all potential locations for the config and its drop-ins.

[1] 6495361c7d ("meson: add build option for install path of main config files")
[2] 6378f257e7 ("various: use new config loader instead of config_parse_config_file()")