### PR TITLE
Support setting up Openvswitch (Ovs) Bridge network

### DIFF
--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -478,6 +478,24 @@ kdump_setup_vlan() {
     _save_kdump_netifs "$_parent_netif"
 }
 
+kdump_setup_ovs() {
+    local _netdev="$1"
+    local _dev _phy_if
+
+    _phy_if=$(ovs_find_phy_if "$_netdev")
+
+    if kdump_is_bridge "$_phy_if"; then
+        kdump_setup_vlan "$_phy_if"
+    elif kdump_is_bond "$_phy_if"; then
+        kdump_setup_bond "$_phy_if" || return 1
+    elif kdump_is_team "$_phy_if"; then
+        derror "Ovs bridge over team is not supported!"
+        exit 1
+    fi
+
+    _save_kdump_netifs "$_phy_if"
+}
+
 # setup s390 znet
 kdump_setup_znet() {
     local _netif
@@ -513,6 +531,28 @@ kdump_get_remote_ip() {
     echo "$_remote"
 }
 
+# Find the physical interface of Open vSwitch (Ovs) bridge
+#
+# The physical network interface has the same MAC address as the Ovs bridge
+ovs_find_phy_if() {
+    local _mac _dev
+    _mac=$(kdump_get_mac_addr $1)
+
+    for _dev in $(ovs-vsctl list-ifaces $1); do
+        if [[ $_mac == $(</sys/class/net/$_dev/address) ]]; then
+            echo -n "$_dev"
+            return
+        fi
+    done
+
+    return 1
+}
+
+# Tell if a network interface is an Open vSwitch (Ovs) bridge
+kdump_is_ovs_bridge() {
+    [[ $(_get_nic_driver $1) == openvswitch ]]
+}
+
 # Collect netifs needed by kdump
 # $1: destination host
 kdump_collect_netif_usage() {
@@ -536,6 +576,9 @@ kdump_collect_netif_usage() {
         kdump_setup_team "$_netdev"
     elif kdump_is_vlan "$_netdev"; then
         kdump_setup_vlan "$_netdev"
+    elif kdump_is_ovs_bridge "$_netdev"; then
+        has_ovs_bridge=yes
+        kdump_setup_ovs "$_netdev"
     fi
     _save_kdump_netifs "$_netdev"
 
@@ -582,6 +625,29 @@ kdump_install_resolv_conf() {
     fi
 }
 
+kdump_install_ovs_deps() {
+    [[ $has_ovs_bridge == yes ]] || return 0
+    inst_multiple -o $(rpm -ql NetworkManager-ovs) $(rpm -ql $(rpm -qf /usr/lib/systemd/system/openvswitch.service)) /sbin/sysctl /usr/bin/uuidgen /usr/bin/hostname /usr/bin/touch /usr/bin/expr /usr/bin/id /usr/bin/install /usr/bin/setpriv /usr/bin/nice /usr/bin/df
+    # 1. Overwrite the copied /etc/sysconfig/openvswitch so
+    # ovsdb-server.service can run as the default user root.
+    # /etc/sysconfig/openvswitch by default intructs ovsdb-server.service to
+    # run as USER=openvswitch, However openvswitch doesn't have the permission
+    # to write to /tmp in kdump initrd and ovsdb-server.servie will fail
+    # with the error "ovs-ctl[1190]: ovsdb-server: failed to create temporary
+    # file (Permission denied)". So run ovsdb-server.service as root instead
+    #
+    # 2. Bypass the error "referential integrity violation: Table Port column
+    # interfaces row" caused by we changing the connection profiles
+    echo "OPTIONS=\"--ovsdb-server-options='--disable-file-column-diff'\"" >"${initdir}/etc/sysconfig/openvswitch"
+
+    KDUMP_DROP_IN_DIR="${initdir}/etc/systemd/system/nm-initrd.service.d"
+    mkdir -p "$KDUMP_DROP_IN_DIR"
+    printf "[Unit]\nAfter=openvswitch.service\n" >$KDUMP_DROP_IN_DIR/01-after-ovs.conf
+
+    $SYSTEMCTL -q --root "$initdir" enable openvswitch.service
+    $SYSTEMCTL -q --root "$initdir" add-wants basic.target openvswitch.service
+}
+
 # Setup dracut to bring up network interface that enable
 # initramfs accessing giving destination
 kdump_install_net() {
@@ -595,6 +661,7 @@ kdump_install_net() {
         kdump_install_nm_netif_allowlist "$_netifs"
         kdump_install_nic_driver "$_netifs"
         kdump_install_resolv_conf
+        kdump_install_ovs_deps
     fi
 }
 
@@ -1006,6 +1073,7 @@ EOF
 
 install() {
     declare -A unique_netifs ipv4_usage ipv6_usage
+    local has_ovs_bridge
 
     kdump_module_init
     kdump_install_conf


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-33465

This patch supports setting up an Ovs bridge in kdump initrd. An Ovs
bridge is similar to a classic Linux bridge but we use ovs-vsctl to find
out the Ethernet device (having the MAC address as the bridge) added to
an Ovs bridge. Once we copy all the needed NetworkManager (NM) connection
profiles to kdump initrd and all the necessary files, NM will create an Ovs bridge
automatically in kdump initrd.

In the case of OpenShift Container Platform (OCP),
ovs-configuration.service [1] is responsible for setting up an Ovs bridge.
In theory, we can also try to bring up the original physical network
interface before ovs-configuration.service. But this approach is
cumbersome because it breaks our assumption that we should bring up the
same network in kdump intrd as in 1st kernel (establishing the same network
in kdump initrd only needs to copy the needed NM connection profiles
thus we don't need to learn how different network setup work under the
hood).

```
How to test this patch with the help of configure-ovs.sh?
=========================================================

1. Extract configure-ovs.sh from [2]

2. Install necessary packages for configure-ovs.sh
    dnf install openvswitch -yq
    dnf install NetworkManager-ovs nmap-ncat -yq

    systemctl enable --now openvswitch

    # restart NM so the ovs plugin can be activated
    systemctl restart NetworkManager

3. Assume the network interface used for creating an Ovs bridge is
   "ens2", use configure-ovs.sh to create an Ovs bridge,

    interface=ens2
    mkdir -p /etc/ovnk
    echo $interface > /etc/ovnk/iface_default_hint
    bash configure-ovs.sh OVNKubernetes

4. (Optional) If you want to make the created Ovs bridge survive a
   reboot, simply make the created NM connections created by
   configure-ovs.sh persist,

    cp /run/NetworkManager/system-connections/ovs-* /etc/NetworkManager/system-connections/

If you need to create an Ovs bridge on top of a bonding network, use the
following commands for step 3,

    nmcli con add type bond ifname bond0
    nmcli con add type ethernet ifname eth0 master bond0
    nmcli con add type ethernet ifname eth1 master bond0

    echo bond0 > /etc/ovnk/iface_default_hint
    bash configure-ovs.sh OVNKubernetes
```

Note
1. For RHEL, openvswitch3.3 may be installed so we need to get the
   package name by "rpm -qf /usr/lib/systemd/system/openvswitch.service"
2. For RHEL9, openvswitch package needs to installed from another repo,
    cat << 'EOF' > /etc/yum.repos.d/ovs.repo
    [rhosp-rhel-9-fdp-cdn]
    name=Red Hat Enterprise Linux Fast Datapath $releasever - $basearch cdn
    baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os/
    enabled=1
    gpgcheck=0
    EOF

    dnf install openvswitch3.3 -yq

[1] https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/units/ovs-configuration.service.yaml
[2] https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml

Signed-off-by: Coiby Xu <coxu@redhat.com>