### PR TITLE
sysconfig: add pcie_ports compat to KDUMP_COMMANDLINE_APPEND on x86_64

### DIFF
--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -104,7 +104,7 @@ s390x)
 x86_64)
 	update_param KEXEC_ARGS "-s"
 	update_param KDUMP_COMMANDLINE_APPEND \
-		"irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off numa=off udev.children-max=2 panic=10 acpi_no_memhotplug transparent_hugepage=never nokaslr hest_disable novmcoredd cma=0 hugetlb_cma=0"
+		"irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off numa=off udev.children-max=2 panic=10 acpi_no_memhotplug transparent_hugepage=never nokaslr hest_disable novmcoredd cma=0 hugetlb_cma=0 pcie_ports=compat"
 	;;
 *)
 	echo "Warning: Unknown architecture '$1', using default sysconfig template." >&2


### PR DESCRIPTION
There have been some of failing cases of kdump in 2nd kernel, where ususally only one cpu is enabled by "nr_cpus=1", but with a large number of devices, which may easily exceed the maximum IRQ resources of one cpu can handle. As a result, the 2nd kernel will hang and kdump fails. This issue is often observed on machines with many cpus and many devices.

On those systems, pcieports consume quite proportion of IRQ resources, many following message can be seen in dmesg log:

   pcieport 0000:18:01.0: PME: Signaling with IRQ 109

According to kernel doc[1], when "pcie_ports=compat" applied, it will disable native PCIe services (PME, AER, DPC, PCIe hotplug). Those functions are power management events, error reporting, performance, hotplug related, which are not the must-have functions for kdump. In addition, after testing, no side effects such as cannot writing vmcore into sdx, nvme etc been noticed.

This patch will disable native PCIe services for 2nd kernel, to saving the scarce IRQ resources and increase the kdump success.

[1]: https://www.kernel.org/doc/html/v6.9-rc1/admin-guide/kernel-parameters.html