### PR TITLE
update 98-kexec rules for crash hotplug

### DIFF
--- a/98-kexec.rules
+++ b/98-kexec.rules
@@ -1,3 +1,7 @@
+# The kernel updates the crash elfcorehdr for CPU and memory changes
+SUBSYSTEM=="cpu", ATTRS{crash_hotplug}=="1", GOTO="kdump_reload_end"
+SUBSYSTEM=="memory", ATTRS{crash_hotplug}=="1", GOTO="kdump_reload_end"
+
 SUBSYSTEM=="cpu", ACTION=="add", GOTO="kdump_reload"
 SUBSYSTEM=="cpu", ACTION=="remove", GOTO="kdump_reload"
 SUBSYSTEM=="memory", ACTION=="online", GOTO="kdump_reload"

--- a/98-kexec.rules.ppc64
+++ b/98-kexec.rules.ppc64
@@ -1,3 +1,7 @@
+# The kernel updates the crash elfcorehdr for CPU and memory changes
+SUBSYSTEM=="cpu", ATTRS{crash_hotplug}=="1", GOTO="kdump_reload_end"
+SUBSYSTEM=="memory", ATTRS{crash_hotplug}=="1", GOTO="kdump_reload_end"
+
 SUBSYSTEM=="cpu", ACTION=="online", GOTO="kdump_reload_cpu"
 SUBSYSTEM=="memory", ACTION=="online", GOTO="kdump_reload_mem"
 SUBSYSTEM=="memory", ACTION=="offline", GOTO="kdump_reload_mem"


### PR DESCRIPTION
In kernel, with the support of cpu/memory hotplug on crash, kdump reloading only needs to update the elfcorehdr.

To realize the benefits, we need prevent udev from updating kdump kernel on hot un/plug changes when detecting that the crash_hotplug sysfs nodes are present.

Link: https://lore.kernel.org/lkml/20230814214446.6659-1-eric.devolder@oracle.com/
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d68b4b6f307d155475cce541f2aee938032ed22e