### PR TITLE
fadump/udev: do not re-register fadump if kernel hotplug ready

### DIFF
--- a/98-kexec.rules.ppc64
+++ b/98-kexec.rules.ppc64
@@ -15,7 +15,9 @@ GOTO="kdump_reload_end"
 
 LABEL="kdump_reload_mem"
 
-RUN+="/bin/sh -c '/usr/bin/systemctl is-active kdump.service || exit 0; /usr/bin/systemd-run --quiet --no-block /usr/lib/udev/kdump-udev-throttler'"
+# Don't re-register fadump if /sys/kernel/fadump/hotplug_ready sysfs is set to 1.
+
+RUN+="/bin/sh -c '/usr/bin/systemctl is-active kdump.service || exit 0; ! test -f /sys/kernel/fadump/hotplug_ready || cat /sys/kernel/fadump/hotplug_ready | grep 1 || exit 0; /usr/bin/systemd-run --quiet --no-block /usr/lib/udev/kdump-udev-throttler'"
 
 GOTO="kdump_reload_end"
 


### PR DESCRIPTION
With the introduction of kernel commit c6c5b14dac0d ("powerpc: make fadump resilient with memory add/remove events") linux kernel now internally manages the update of elfcorehdr during memory add/remove events. So no need to re-register fadump if the /sys/kernel/fadump/hotplug_ready is set to 1.

No impact for kernels that do not have /sys/kernel/fadump/hotplug_ready sysfs.

Relevant kernel commit links:
1. https://msgid.link/20240422195932.1583833-2-sourabhjain@linux.ibm.com
2. https://msgid.link/20240422195932.1583833-3-sourabhjain@linux.ibm.com