### PR TITLE
kdump LUKS support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - run: dnf install shellcheck -y
       # Currently, for kdump-utils, there is need for shellcheck to require
       # the sourced file to give correct warnings about the checked file
-      - run: shellcheck -x *.sh  kdumpctl mk*dumprd
+      - run: shellcheck -x *.sh  kdumpctl mk*dumprd kdump-udev-throttler
       - run: shellcheck -x dracut/*/*.sh
       - run: shellcheck -x tests/*/*/*.sh tools/*.sh
       # disable the follow checks for unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: dnf install shfmt -y
-      - run: shfmt -s -d *.sh kdumpctl mk*dumprd tests/*/*/*.sh dracut/*/*.sh tools/*.sh
+      - run: shfmt -s -d *.sh kdumpctl mk*dumprd kdump-udev-throttler tests/*/*/*.sh dracut/*/*.sh tools/*.sh
 
   static-analysis:
     runs-on: ubuntu-latest

--- a/dracut/99kdumpbase/kexec-crypt-setup.sh
+++ b/dracut/99kdumpbase/kexec-crypt-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+echo true > /sys/kernel/config/crash_dm_crypt_keys/restore

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1135,6 +1135,13 @@ $CRYPTSETUP_PATH luksOpen --volume-key-keyring \
 EOF
     done
 
+    # latest systemd makes /usr read-only by default
+    mkdir -p "${initdir}/etc/systemd/system.conf.d"
+    cat << EOF > "${initdir}/etc/systemd/system.conf.d/kdump_luks.conf"
+[Manager]
+ProtectSystem=false
+EOF
+
     dracut_need_initqueue
 }
 

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -11,6 +11,10 @@ KDUMP_CONFIG_FILE="/etc/kdump.conf"
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
 # shellcheck disable=SC2034
 LVM_CONF="/etc/lvm/lvm.conf"
+# shellcheck disable=SC2034
+LUKS_CONFIGFS=/sys/kernel/config/crash_dm_crypt_keys
+# shellcheck disable=SC2034
+LUKS_KEY_PRFIX="systemd-cryptsetup:vk-"
 
 # Read kdump config in well formated style
 kdump_read_conf()

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -1093,6 +1093,11 @@ get_luks_crypt_dev()
 	done
 }
 
+maj_min_to_uuid()
+{
+	lsblk -no uuid,MAJ:MIN | awk -v dev="$1" 'NF==2 && $2 == dev {print $1}'
+}
+
 # kdump_get_maj_min <device>
 # Prints the major and minor of a device node.
 # Example:

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -26,15 +26,14 @@ unuse_luks_keys()
 
 	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 0 > $LUKS_CONFIGFS_REUSE
 }
-exec 9> $throttle_lock
-if [ $? -ne 0 ]; then
+
+if ! exec 9> $throttle_lock; then
 	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
 	/bin/kdumpctl reload
 	exit 1
 fi
 
-flock -n 9
-if [ $? -ne 0 ]; then
+if ! flock -n 9; then
 	echo "Throttling kdump restart for concurrent udev event"
 	exit 0
 fi

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -15,17 +15,17 @@
 
 throttle_lock="/var/lock/kdump-udev-throttle"
 
-exec 9>$throttle_lock
+exec 9> $throttle_lock
 if [ $? -ne 0 ]; then
-        echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
-        /bin/kdumpctl reload
-        exit 1
+	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
+	/bin/kdumpctl reload
+	exit 1
 fi
 
 flock -n 9
 if [ $? -ne 0 ]; then
-        echo "Throttling kdump restart for concurrent udev event"
-        exit 0
+	echo "Throttling kdump restart for concurrent udev event"
+	exit 0
 fi
 
 # Wait for at least 1 second, at most 4 seconds for udev to settle

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -15,6 +15,17 @@
 
 throttle_lock="/var/lock/kdump-udev-throttle"
 
+LUKS_CONFIGFS_REUSE=/sys/kernel/config/crash_dm_crypt_keys/reuse
+reuse_luks_keys()
+{
+	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 1 > $LUKS_CONFIGFS_REUSE
+}
+
+unuse_luks_keys()
+{
+
+	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 0 > $LUKS_CONFIGFS_REUSE
+}
 exec 9> $throttle_lock
 if [ $? -ne 0 ]; then
 	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
@@ -37,6 +48,8 @@ sleep 1 && udevadm settle --timeout 3
 # holding two locks at the same time and we might miss some events
 exec 9>&-
 
+reuse_luks_keys
 /bin/kdumpctl reload
+unuse_luks_keys
 
 exit 0

--- a/kdumpctl
+++ b/kdumpctl
@@ -1105,6 +1105,9 @@ prepare_luks()
 		return 1
 	fi
 
+	# For the case of CPU/memory hotplugging, we can reuse loaded keys
+	[[ $(cat $LUKS_CONFIGFS/reuse) == 1 ]] && return 0
+
 	for _luks_dev in "${_luks_devs[@]}"; do
 		_devuuid=$(maj_min_to_uuid "$_luks_dev")
 		_key_dir=$LUKS_CONFIGFS/$_devuuid

--- a/kdumpctl
+++ b/kdumpctl
@@ -1056,9 +1056,42 @@ check_final_action_config()
 	esac
 }
 
+_get_luks_key_by_unlock()
+{
+	local _devuuid=$1 _key_des=$2
+	local _max_retries
+	local _attempt=1
+
+	local _luks_unlock_cmd=""
+
+	# Check if stdin is a terminal.
+	if [ -t 0 ]; then
+		_max_retries=5
+		ddebug "Attempting to unlock LUKS device. You have $_max_retries attempts."
+	else
+		# Not a terminal (e.g., running as system service), so only try once
+		# for cases where volume key is sealed to TPM which doesn't need user
+		# interaction.
+		_max_retries=1
+		ddebug "Attempting to unlock LUKS device (non-interactive mode)..."
+	fi
+
+	while [ "$_attempt" -le "$_max_retries" ]; do
+		if cryptsetup open "UUID=$_devuuid" DUMMY "--link-vk-to-keyring=@u::%logon:$_key_des" --test-passphrase; then
+			ddebug "Success: LUKS device unlocked."
+			dwarn "To avoid manually running kdumpctl, ensure the link-volume-key=@u::%logon:$_key_des option is correctly set up in /etc/crypttab (see man crypttab)."
+			return 0
+		fi
+		_attempt=$((_attempt + 1))
+	done
+
+	derror "Error: Could not unlock the LUKS device."
+	return 1
+}
+
 prepare_luks()
 {
-	local _luks_dev _key_id _key_des
+	local _luks_dev _key_id _key_des _luks_unlock_cmd
 	declare -a _luks_devs
 
 	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
@@ -1077,12 +1110,19 @@ prepare_luks()
 		_key_dir=$LUKS_CONFIGFS/$_devuuid
 		_key_des=$LUKS_KEY_PRFIX$_devuuid
 		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then
-			mkdir "$_key_dir"
-			printf "%s" "$_key_des" > "$_key_dir"/description
+			ddebug "Succesfully get @u::%logon:$_key_des"
+		elif _get_luks_key_by_unlock "$_devuuid" "$_key_des"; then
+			_key_id=$(keyctl request logon "$_key_des")
+			ddebug "Succesfully get @u::%logon:$_key_des after cryptsetup"
 		else
-			derror "Failed to get logon key $_key_des. Ensure the link-volume-key option is correctly set up in /etc/crypttab (see man crypttab) and that the key is available."
+			derror "Failed to get logon key $_key_des. Run 'kdumpctl restart' manually to start kdump."
 			return 1
 		fi
+
+		# Let the key expire after 300 seconds
+		keyctl timeout "$_key_id" 300
+		mkdir "$_key_dir"
+		printf "%s" "$_key_des" > "$_key_dir"/description
 	done
 }
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -52,6 +52,7 @@ trap '
     ret=$?;
     is_mounted $TMPMNT && umount -f $TMPMNT;
     rm -rf "$KDUMP_TMPDIR"
+    [[ -d $LUKS_CONFIGFS ]] && find $LUKS_CONFIGFS/ -mindepth 1 -type d -delete
     exit $ret;
     ' EXIT
 
@@ -731,6 +732,11 @@ load_kdump()
 	args+=("--initrd=$TARGET_INITRD")
 	args+=("$KDUMP_KERNEL")
 
+	if ! prepare_luks; then
+		derror "kexec: failed to prepare for a LUKS target"
+		return 1
+	fi
+
 	ddebug "$KEXEC ${args[*]}"
 	if $KEXEC "${args[@]}"; then
 		dinfo "kexec: loaded kdump kernel"
@@ -1048,6 +1054,36 @@ check_final_action_config()
 		return 1
 		;;
 	esac
+}
+
+prepare_luks()
+{
+	local _luks_dev _key_id _key_des
+	declare -a _luks_devs
+
+	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
+
+	if [[ ${#_luks_devs[@]} -lt 1 ]]; then
+		return
+	fi
+
+	if [[ ! -d $LUKS_CONFIGFS ]]; then
+		dwarn "$LUKS_CONFIGFS not available, please use a newer kernel."
+		return 1
+	fi
+
+	for _luks_dev in "${_luks_devs[@]}"; do
+		_devuuid=$(maj_min_to_uuid "$_luks_dev")
+		_key_dir=$LUKS_CONFIGFS/$_devuuid
+		_key_des=$LUKS_KEY_PRFIX$_devuuid
+		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then
+			mkdir "$_key_dir"
+			printf "%s" "$_key_des" > "$_key_dir"/description
+		else
+			derror "Failed to get logon key $_key_des. Ensure the link-volume-key option is correctly set up in /etc/crypttab (see man crypttab) and that the key is available."
+			return 1
+		fi
+	done
 }
 
 start()

--- a/mkdumprd
+++ b/mkdumprd
@@ -318,21 +318,6 @@ handle_default_dump_target()
 	check_size fs "$_target"
 }
 
-check_crypt()
-{
-	local _dev
-
-	for _dev in $(get_kdump_targets); do
-		if [[ -n $(get_luks_crypt_dev "$(get_maj_min "$_dev")") ]]; then
-			derror "Device $_dev is encrypted." && return 1
-		fi
-	done
-}
-
-if ! check_crypt; then
-	dwarn "Warning: Encrypted device is in dump path, which is not recommended, see kexec-kdump-howto.txt for more details."
-fi
-
 # firstly get right SSH_KEY_LOCATION
 keyfile=$(kdump_get_conf_val sshkey)
 if [[ -f $keyfile ]]; then

--- a/supported-kdump-targets.txt
+++ b/supported-kdump-targets.txt
@@ -49,6 +49,7 @@ storage:
         NVMe-FC (qla2xxx, lpfc)
         NVMe/TCP configured by NVMe Boot Firmware Table (users may need to
             increase the crashkernel value)
+        LUKS-encrypted volume
 
 network:
         Hardware using kernel modules: (igb, ixgbe, ice, i40e, e1000e, igc,


### PR DESCRIPTION
LUKS is the standard for Linux disk encryption. Many users choose LUKS
and in some use cases like Confidential VM it's mandated. With kdump
enabled, when the 1st kernel crashes, the system could boot into the
kdump/crash kernel and dump the memory image i.e. /proc/vmcore to a
specified target. Currently, when dumping vmcore to a LUKS
encrypted device, there are two problems,

 - Kdump kernel may not be able to decrypt the LUKS partition. For some
   machines, a system administrator may not have a chance to enter the
   password to decrypt the device in kdump initramfs after the 1st kernel
   crashes; For cloud confidential VMs, depending on the policy the
   kdump kernel may not be able to unseal the keys with TPM and the
   console virtual keyboard is untrusted.

 - LUKS2 by default use the memory-hard Argon2 key derivation function
   which is quite memory-consuming compared to the limited memory reserved
   for kdump. Take Fedora example, by default, only 256M is reserved for
   systems having memory between 4G-64G. With LUKS enabled, ~1300M needs
   to be reserved for kdump. Note if the memory reserved for kdump can't
   be used by 1st kernel i.e. an user sees ~1300M memory missing in the
   1st kernel.

Based on the new kernel feature that dm-crypt keys can persist for the
kdump kernel [1][2], this patch which is adapted from [3]
1) ask the 1st kernel to save a copy of the LUKS volume keys
2) ask the kdump kernel to add the copy of the LUKS volume keys to
   specified keyring and then use --volume-key-keyring the unlock the
   LUKS device.

Users need to set up the link-volume-key option in /etc/crypttab (man
crypttab) so kdumpctl can read the key from @u::%logon:cryptsetup:UUID
and instruct the kernel to save it to kdump-reserved memory.

[1] https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/kdump/kdump.rst#write-the-dump-file-to-encrypted-disk-volume
[2] https://github.com/torvalds/linux/commit/180cf31af7c313790f1e0fba1c7aa42512144dd5
[3] https://lists.fedorahosted.org/archives/list/kexec@lists.fedoraproject.org/message/Y3KUSJQPN3JHUUC2FPIK7H4HTSX2TUCX/
