### PR TITLE
Remove default debug option

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -5,7 +5,6 @@ KDUMP_KERNELVER=""
 KDUMP_KERNEL=""
 KDUMP_COMMANDLINE=""
 KEXEC_ARGS=""
-KDUMP_LOG_PATH="/var/log"
 MKDUMPRD="/sbin/mkdumprd -f"
 MKFADUMPRD="/sbin/mkfadumprd"
 DRACUT_MODULES_FILE="/usr/lib/dracut/modules.txt"
@@ -17,7 +16,7 @@ TARGET_INITRD=""
 #kdump shall be the default dump mode
 DEFAULT_DUMP_MODE="kdump"
 
-standard_kexec_args="-d -p"
+standard_kexec_args="-p"
 
 # Some default values in case /etc/sysconfig/kdump doesn't include
 KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug"
@@ -696,7 +695,7 @@ function load_kdump_kernel_key()
 # as the currently running kernel.
 load_kdump()
 {
-	local ret uki
+	local uki
 
 	KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
 	KDUMP_COMMANDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
@@ -713,26 +712,12 @@ load_kdump()
 
 	ddebug "$KEXEC $KEXEC_ARGS $standard_kexec_args --command-line=$KDUMP_COMMANDLINE --initrd=$TARGET_INITRD $KDUMP_KERNEL"
 
-	# The '12' represents an intermediate temporary file descriptor
-	# to store the standard error file descriptor '2', and later
-	# restore the error file descriptor with the file descriptor '12'
-	# and release it.
-	exec 12>&2
-	exec 2>> $KDUMP_LOG_PATH/kdump.log
-	chmod 600 $KDUMP_LOG_PATH/kdump.log
-	PS4='+ $(date "+%Y-%m-%d %H:%M:%S") ${BASH_SOURCE}@${LINENO}: '
-	set -x
-
 	# shellcheck disable=SC2086
 	$KEXEC $KEXEC_ARGS $standard_kexec_args \
 		--command-line="$KDUMP_COMMANDLINE" \
 		--initrd="$TARGET_INITRD" "$KDUMP_KERNEL"
 
-	ret=$?
-	set +x
-	exec 2>&12 12>&-
-
-	if [[ $ret == 0 ]]; then
+	if [[ $? == 0 ]]; then
 		dinfo "kexec: loaded kdump kernel"
 		return 0
 	else

--- a/kexec-kdump-howto.txt
+++ b/kexec-kdump-howto.txt
@@ -1016,12 +1016,7 @@ Debugging Tips
   and the second kernel.
 
   In the first kernel, you can find the historical logs with the journalctl
-  command and check kdump service debugging information. In addition, the
-  'kexec -d' debugging messages are also saved to /var/log/kdump.log in the
-  first kernel. For example:
-
-  [root@ibm-z-109 ~]# ls -al /var/log/kdump.log
-  -rw-r--r--. 1 root root 63238 Oct 28 06:40 /var/log/kdump.log
+  command and check kdump service debugging information.
 
   If you want to get the debugging information of building kdump initramfs, you
   can enable the '--debug' option for the dracut_args in the /etc/kdump.conf, and


### PR DESCRIPTION
This series removes the -d option set per default to kexec followed by some small cleanup patches. Please see the patch description for details