### PR TITLE
[RFC] Use all available CPUs to collect dump

### DIFF
--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -32,6 +32,7 @@ KDUMP_POST=""
 NEWROOT="/sysroot"
 OPALCORE="/sys/firmware/opal/mpipl/core"
 KDUMP_CONF_PARSED="/tmp/kdump.conf.$$"
+KDUMP_CPUS=0
 
 # POSIX doesn't have pipefail, only apply when using bash
 # shellcheck disable=SC3040
@@ -40,6 +41,23 @@ KDUMP_CONF_PARSED="/tmp/kdump.conf.$$"
 DUMP_RETVAL=0
 
 kdump_read_conf > $KDUMP_CONF_PARSED
+
+get_cpus_count()
+{
+	CPUS=1
+	ONLINE_CPUS=$(nproc)
+
+	if [ "$KDUMP_CPUS" -lt "1" ]; then
+		CPUS="$ONLINE_CPUS"
+	elif [ "$KDUMP_CPUS" -lt "$ONLINE_CPUS" ]; then
+		CPUS=$KDUMP_CPUS
+	else
+		CPUS=$ONLINE_CPUS
+	fi
+
+	echo "$CPUS"
+	return
+}
 
 get_kdump_confs()
 {
@@ -68,6 +86,9 @@ get_kdump_confs()
 			;;
 		fence_kdump_nodes)
 			FENCE_KDUMP_NODES="$config_val"
+			;;
+		kdump_cpus)
+			KDUMP_CPUS="$config_val"
 			;;
 		failure_action | default)
 			case $config_val in
@@ -146,7 +167,9 @@ dump_fs()
 	# Remove -F in makedumpfile case. We don't want a flat format dump here.
 	case $CORE_COLLECTOR in
 	*makedumpfile*)
+		THREADS=$(get_cpus_count)
 		CORE_COLLECTOR=$(echo "$CORE_COLLECTOR" | sed -e "s/-F//g")
+		CORE_COLLECTOR="$CORE_COLLECTOR --num-thread=$THREADS"
 		;;
 	esac
 
@@ -378,6 +401,11 @@ dump_raw()
 		_src_size=$(stat --format %s /proc/vmcore)
 		_src_size_mb=$((_src_size / 1048576))
 		/kdumpscripts/monitor_dd_progress.sh $_src_size_mb &
+	fi
+
+	if echo "$CORE_COLLECTOR" | grep -q makedumpfile; then
+		THREADS=$(get_cpus_count)
+		CORE_COLLECTOR="$CORE_COLLECTOR --num-thread=$THREADS"
 	fi
 
 	dinfo "saving vmcore"

--- a/gen-kdump-conf.sh
+++ b/gen-kdump-conf.sh
@@ -169,6 +169,11 @@ generate()
 #             to send fence_kdump notifications to.
 #             (this option is mandatory to enable fence_kdump).
 #
+# kdump_cpus <cpu count>
+#           - Number of CPUs used in the kdump environment by the core collector
+#             to collect the dump. Currently, it is only used with the default
+#             dump collector, which is makedumpfile. By default, or if set to 0,
+#             all CPUs available in the kdump environment are used for dump collection.
 
 #raw /dev/vg/lv_kdump
 #ext4 /dev/vg/lv_kdump
@@ -194,6 +199,7 @@ core_collector makedumpfile -l --message-level 7 -d 31
 #dracut_args --omit-drivers "cfg80211 snd" --add-drivers "ext2 ext3"
 #fence_kdump_args -p 7410 -f auto -c 0 -i 10
 #fence_kdump_nodes node1 node2
+#kdump_cpus 0
 EOF
 }
 

--- a/kdump.conf.5
+++ b/kdump.conf.5
@@ -258,6 +258,14 @@ to (this option is mandatory to enable fence_kdump).
 .RE
 
 
+.B kdump_cpus <cpu count>
+.RS
+Number of CPUs used in the kdump environment by the core collector to collect the dump.
+Currently, it is only used with the default dump collector, which is makedumpfile.
+By default, or if set to 0, all CPUs available in the kdump environment are used for dump collection.
+.RE
+
+
 .SH DEPRECATED OPTIONS
 
 .B net <nfs mount>|<user@server>

--- a/kdumpctl
+++ b/kdumpctl
@@ -321,7 +321,7 @@ parse_config()
 			dwarn "Please update $KDUMP_CONFIG_FILE to use option 'failure_action' instead."
 			_set_config failure_action "$config_val" || return 1
 			;;
-		path | core_collector | kdump_post | kdump_pre | extra_bins | extra_modules | failure_action | final_action | force_rebuild | force_no_rebuild | fence_kdump_args | fence_kdump_nodes | auto_reset_crashkernel) ;;
+		path | core_collector | kdump_post | kdump_pre | extra_bins | extra_modules | failure_action | final_action | force_rebuild | force_no_rebuild | fence_kdump_args | kdump_cpus | fence_kdump_nodes | auto_reset_crashkernel) ;;
 
 		net | options | link_delay | disk_timeout | debug_mem_level | blacklist)
 			derror "Deprecated kdump config option: $config_opt. Refer to kdump.conf manpage for alternatives."


### PR DESCRIPTION
By default, use all available CPUs to collect the dump instead of just one CPU. This reduces the dump collection time significantly, specially for the systems with very large memory configuration.

The graph below show the time reduction in dump collection on large memory system from 4 Hours to 10 Minutes.

                               |
                       14000   | *
                               |
                               |
                               |
                               |
                               |
                               |
                        1600   |      *
                               |
                               |
                        1400   |
 execution Time (Sec)          |
                               |
                        1200   |
                               |
                               |
                        1000   |
                               |            *
                               |
                        800    |
                               |
                               |                   *
                        600    |
                               |                          *     *
                               |
                                ------------------------------------
                                   1    9    17    25     33    41

                                          Number of Threads

System details:
Architecture: PowerPC
/proc/vmcore size: 3.7T
Filter level: 1

Similar tests with different filter levels, 31 and 16, also show significant reduction in time consumption for dump collection.

Although the above tests were performed only on the PowerPC architecture, but I think using all CPUs for dump collection will have performance benefits on other architectures too.

A new configuration parameter, `kdump_cpus`, is introduced to allow users to control the number of CPUs used for dump collection. If `kdump_cpus` is set to a negative value or if the configured CPU count is larger than the available CPUs in the kdump kernel, it will fall back to the default value, which is all available CPUs.

Note: The newly introduced configuration is only applicable to the makedumpfile core collector for now.