### PR TITLE
kdumpctl: Only update fadump for ppc64le 

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1561,7 +1561,7 @@ reset_crashkernel()
 		_old_ck=$(get_grub_kernel_boot_parameter "$_kernel" crashkernel)
 		_new_ck=$(kdump_get_arch_recommend_crashkernel "$_new_dump_mode")
 		_old_fadump=$(get_grub_kernel_boot_parameter "$_kernel" fadump)
-		if _update_kernel_cmdline "$_kernel" fadump "$_old_fadump" "$_new_fadump"; then
+		if [[ $(uname -m) == ppc64le ]] && _update_kernel_cmdline "$_kernel" fadump "$_old_fadump" "$_new_fadump"; then
 			_has_changed="Updated fadump=$_new_fadump"
 		fi
 		if _update_kernel_cmdline "$_kernel" crashkernel "$_old_ck" "$_new_ck"; then

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -62,6 +62,11 @@ grubby's kernel-path=ALL and kernel-path=DEFAULT. ppc64le supports FADump and
 supports an additional [--fadump=[on|off|nocma]] parameter to toggle FADump
 on/off.
 
+If the [--reboot] parameter is used, the operating system will automatically reboot only
+if changes occur to crashkernel or fadump during this run. That means, if you run
+kdumpctl reset-crashkernel --reboot but nothing has been changed, the operating system
+will not reboot.
+
 Note: The memory requirements for kdump varies heavily depending on the
 used hardware and system configuration. Thus the recommended
 crashkernel might not work for your specific setup. Please test if


### PR DESCRIPTION
Fadump is only available for ppc64le, but reset_crashkernel() updates fadump
unconditionally, which will cause non-ppc64le architectures to always reboot
when run kdumpctl reset-crashkernel --reboot.