### PR TITLE
Add kdump dracut config

### DIFF
--- a/99-kdump.conf
+++ b/99-kdump.conf
@@ -1,0 +1,3 @@
+dracutmodules=''
+add_dracutmodules=' kdumpbase '
+omit_dracutmodules=' rdma plymouth resume ifcfg earlykdump '

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ manpages:
 	install -D -m 644 kdump.conf.5 $(DESTDIR)$(mandir)/man5/kdump.conf.5
 
 install: dracut-modules kdump-conf kdump-sysconfig manpages
-	mkdir -p $(DESTDIR)$(pkglibdir)
+	mkdir -p $(DESTDIR)$(pkglibdir)/dracut.conf.d
 	mkdir -p -m755 $(DESTDIR)$(sysconfdir)/kdump/pre.d
 	mkdir -p -m755 $(DESTDIR)$(sysconfdir)/kdump/post.d
 	mkdir -p -m755 $(DESTDIR)$(localstatedir)/crash
@@ -46,6 +46,7 @@ install: dracut-modules kdump-conf kdump-sysconfig manpages
 	install -D -m 644 kdump.conf $(DESTDIR)$(sysconfdir)
 	install -D -m 644 kdump.sysconfig $(DESTDIR)$(sysconfdir)/sysconfig/kdump
 	install -D -m 755 kdump-lib.sh kdump-lib-initramfs.sh kdump-logger.sh -t $(DESTDIR)$(pkglibdir)
+	install -D -m 644 99-kdump.conf -t $(DESTDIR)$(pkglibdir)/dracut.conf.d
 
 ifeq ($(ARCH), $(filter ppc64le ppc64,$(ARCH)))
 	install -m 755 mkfadumprd $(DESTDIR)$(sbindir)

--- a/mkdumprd
+++ b/mkdumprd
@@ -29,7 +29,6 @@ SSH_KEY_LOCATION=$DEFAULT_SSHKEY
 SAVE_PATH=$(get_save_path)
 
 declare -a dracut_args
-dracut_args+=(--add kdumpbase)
 dracut_args+=(--quiet)
 dracut_args+=(--hostonly)
 dracut_args+=(--hostonly-cmdline)
@@ -37,7 +36,6 @@ dracut_args+=(--hostonly-i18n)
 dracut_args+=(--hostonly-mode strict)
 dracut_args+=(--hostonly-nics '')
 dracut_args+=(--aggressive-strip)
-dracut_args+=(--omit "rdma plymouth resume ifcfg earlykdump")
 
 MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."
@@ -439,6 +437,15 @@ if [[ $(get_root_fs_device) != "$status_target" ]]; then
 elif ! is_fadump_capable && \
      ! [[ ${dracut_args[@]} == *"$(kdump_get_persistent_dev $status_target)"* ]]; then
 	add_mount "$status_target"
+fi
+
+# Use kdump managed dracut profile.
+[[ $kdump_dracut_confdir ]] || kdump_dracut_confdir=/lib/kdump/dracut.conf.d
+if [[ "$(dracut --help)" == *--add-confdir* ]] && [[ -d "$kdump_dracut_confdir" ]]; then
+	dracut_args+=("--add-confdir" "$kdump_dracut_confdir")
+else
+	dracut_args+=(--add kdumpbase)
+	dracut_args+=(--omit "rdma plymouth resume ifcfg earlykdump")
 fi
 
 dracut "${dracut_args[@]}" "$@"


### PR DESCRIPTION
In some cases, we need to change dracut [omit_]dracutmodules to customize the first kernel's initrd to meet the needs, such as bootc and CoreOS.

In most cases kdump does not use these modules, but the change of [omit]_dracutmodules may break existing functionality. For example, if we set omit_dracutmodules='nfs', the nfs module cannot be added even if we use "dracut_args --force-add 'nfs'".

It is better to maintain its own dracut config for kdump. As the first try, we start by keeping [omit_]dracutmodules empty.

As a side effect, the default confdir "/etc/dracut.conf.d" will not work while generating kdump initrd.

And dracut can only use --confdir once, so "dracut_args --confidr" in /etc/kdump.conf will no longer work. This may be avoided in the future by adding something like "--extra-confdir" to dracut.