### PR TITLE
mkdumprd: Omit rdma module

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -37,7 +37,7 @@ dracut_args+=(--hostonly-i18n)
 dracut_args+=(--hostonly-mode strict)
 dracut_args+=(--hostonly-nics '')
 dracut_args+=(--aggressive-strip)
-dracut_args+=(--omit "plymouth resume ifcfg earlykdump")
+dracut_args+=(--omit "rdma plymouth resume ifcfg earlykdump")
 
 MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-57006

05rdma dracut module from rdma-core is installed unconditionally even if kdump dumps the vmcore to local disk. And those kmod will cost additional 200M memory on x86, which likely triggers OOM.

Since the Infiniband (and in fact none of RDMA devices are supported in kdump), exclude the rdma dracut module explicitly.