### PR TITLE
Bind mount and btrfs dump target enhancement

### DIFF
--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -541,12 +541,12 @@ read_kdump_confs() {
             dracut_args)
                 config_val=$(get_dracut_args_target "$config_val")
                 if [ -n "$config_val" ]; then
-                    config_val=$(get_mntpoint_from_target "$config_val")
+                    config_val=$(get_mntpoint_from_dump_target "$config_val")
                     DUMP_INSTRUCTION="dump_fs $config_val"
                 fi
                 ;;
             ext[234] | xfs | btrfs | minix | nfs | virtiofs)
-                config_val=$(get_mntpoint_from_target "$config_val")
+                config_val=$(get_mntpoint_from_dump_target "$config_val")
                 DUMP_INSTRUCTION="dump_fs $config_val"
                 ;;
             raw)

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -690,9 +690,9 @@ default_dump_target_install_conf() {
 
     _save_path=$(get_bind_mount_source "$(get_save_path)")
     _target=$(get_target_from_path "$_save_path")
-    _mntpoint=$(get_mntpoint_from_target "$_target")
+    _mntpoint=$(get_mntpoint_from_dump_target "$_target")
 
-    _fstype=$(get_fs_type_from_target "$_target")
+    _fstype=$(get_fs_type_from_dump_target "$_target")
     if is_fs_type_nfs "$_fstype"; then
         kdump_collect_netif_usage "$_target"
         _fstype="nfs"

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -683,16 +683,17 @@ kdump_install_pre_post_conf() {
 }
 
 default_dump_target_install_conf() {
-    local _target _fstype
+    local _target _fstype _subvol
     local _mntpoint _save_path
 
     is_user_configured_dump_target && return
 
     _save_path=$(get_bind_mount_source "$(get_save_path)")
     _target=$(get_target_from_path "$_save_path")
-    _mntpoint=$(get_mntpoint_from_dump_target "$_target")
-
     _fstype=$(get_fs_type_from_dump_target "$_target")
+    [[ $_fstype == "btrfs" ]] && _subvol=$(get_btrfs_subvol_from_mntpoint "$_save_path")
+    _mntpoint=$(get_mntpoint_from_dump_target "$_target" "$_subvol")
+
     if is_fs_type_nfs "$_fstype"; then
         kdump_collect_netif_usage "$_target"
         _fstype="nfs"

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -102,8 +102,10 @@ get_fs_type_from_target()
 
 get_mntpoint_from_target()
 {
-	# --source is applied to ensure non-bind mount is returned
-	get_mount_info TARGET source "$1" -f
+	local _mntpoint
+	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
+	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f )
+	echo $_mntpoint
 }
 
 is_ssh_dump_target()

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -95,12 +95,12 @@ get_target_from_path()
 	echo "$__kdump_target"
 }
 
-get_fs_type_from_target()
+get_fs_type_from_dump_target()
 {
 	get_mount_info FSTYPE source "$1" -f
 }
 
-get_mntpoint_from_target()
+get_mntpoint_from_dump_target()
 {
 	local _mntpoint
 	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
@@ -108,18 +108,18 @@ get_mntpoint_from_target()
 	echo $_mntpoint
 }
 
-get_mntopt_from_target()
+get_mntopt_from_dump_target()
 {
 	get_mount_info OPTIONS source "$1" -f
 }
 
 # Get the path where the target will be mounted in kdump kernel
 # $1: kdump target device
-get_kdump_mntpoint_from_target()
+get_kdump_mntpoint_from_dump_target()
 {
 	local _mntpoint
 
-	_mntpoint=$(get_mntpoint_from_target "$1")
+	_mntpoint=$(get_mntpoint_from_dump_target "$1")
 	# mount under /sysroot if dump to root disk or mount under
 	# mount under /kdumproot if dump target is not mounted in first kernel
 	# mount under /kdumproot/$_mntpoint in other cases in 2nd kernel.
@@ -158,7 +158,7 @@ is_virtiofs_dump_target()
 		return 0
 	fi
 
-	if is_fs_type_virtiofs "$(get_fs_type_from_target "$(get_target_from_path "$(get_save_path)")")"; then
+	if is_fs_type_virtiofs "$(get_fs_type_from_dump_target "$(get_target_from_path "$(get_save_path)")")"; then
 		return 0
 	fi
 
@@ -175,7 +175,7 @@ is_nfs_dump_target()
 		return 0
 	fi
 
-	if is_fs_type_nfs "$(get_fs_type_from_target "$(get_target_from_path "$(get_save_path)")")"; then
+	if is_fs_type_nfs "$(get_fs_type_from_dump_target "$(get_target_from_path "$(get_save_path)")")"; then
 		return 0
 	fi
 

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -108,6 +108,36 @@ get_mntpoint_from_target()
 	echo $_mntpoint
 }
 
+get_mntopt_from_target()
+{
+	get_mount_info OPTIONS source "$1" -f
+}
+
+# Get the path where the target will be mounted in kdump kernel
+# $1: kdump target device
+get_kdump_mntpoint_from_target()
+{
+	local _mntpoint
+
+	_mntpoint=$(get_mntpoint_from_target "$1")
+	# mount under /sysroot if dump to root disk or mount under
+	# mount under /kdumproot if dump target is not mounted in first kernel
+	# mount under /kdumproot/$_mntpoint in other cases in 2nd kernel.
+	# systemd will be in charge to umount it.
+	if [[ -z $_mntpoint ]]; then
+		_mntpoint="/kdumproot"
+	else
+		if [[ $_mntpoint == "/" ]]; then
+			_mntpoint="/sysroot"
+		else
+			_mntpoint="/kdumproot/$_mntpoint"
+		fi
+	fi
+
+	# strip duplicated "/"
+	echo $_mntpoint | tr -s "/"
+}
+
 is_ssh_dump_target()
 {
 	kdump_get_conf_val ssh | grep -q @

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -183,7 +183,7 @@ get_kdump_targets()
 get_bind_mount_source()
 {
 	local _mnt _path _src _opt _fstype
-	local _fsroot _src_nofsroot
+	local _fsroot _src_nofsroot _subvol
 
 	_mnt=$(df "$1" | tail -1 | awk '{print $NF}')
 	_path=${1#"$_mnt"}
@@ -205,15 +205,14 @@ get_bind_mount_source()
 
 	_fsroot=${_src#"${_src_nofsroot}"[}
 	_fsroot=${_fsroot%]}
-	_mnt=$(get_mount_info TARGET source "$_src_nofsroot" -f)
 
 	# for btrfs, _fsroot will also contain the subvol value as well, strip it
 	if [[ $_fstype == btrfs ]]; then
-		local _subvol
 		_subvol=${_opt#*subvol=}
 		_subvol=${_subvol%,*}
 		_fsroot=${_fsroot#"$_subvol"}
 	fi
+	_mnt=$(get_mntpoint_from_dump_target "$_src_nofsroot" "$_subvol")
 	echo "$_mnt$_fsroot$_path"
 }
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -115,7 +115,7 @@ get_block_dump_target()
 	_target=$(get_target_from_path "$(get_save_path)")
 	[[ -b $_target ]] && to_dev_name "$_target" && return
 
-	_fstype=$(get_fs_type_from_target "$_target")
+	_fstype=$(get_fs_type_from_dump_target "$_target")
 	is_fs_type_virtiofs "$_fstype" && echo "$_target" && return
 }
 
@@ -138,7 +138,7 @@ get_failure_action_target()
 		# Get rootfs device name
 		_target=$(get_root_fs_device)
 		[[ -b $_target ]] && to_dev_name "$_target" && return
-		is_fs_type_virtiofs "$(get_fs_type_from_target "$_target")" && echo "$_target" && return
+		is_fs_type_virtiofs "$(get_fs_type_from_dump_target "$_target")" && echo "$_target" && return
 		# Then, must be nfs root
 		echo "nfs"
 	fi

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -217,36 +217,6 @@ get_bind_mount_source()
 	echo "$_mnt$_fsroot$_path"
 }
 
-get_mntopt_from_target()
-{
-	get_mount_info OPTIONS source "$1" -f
-}
-
-# Get the path where the target will be mounted in kdump kernel
-# $1: kdump target device
-get_kdump_mntpoint_from_target()
-{
-	local _mntpoint
-
-	_mntpoint=$(get_mntpoint_from_target "$1")
-	# mount under /sysroot if dump to root disk or mount under
-	# mount under /kdumproot if dump target is not mounted in first kernel
-	# mount under /kdumproot/$_mntpoint in other cases in 2nd kernel.
-	# systemd will be in charge to umount it.
-	if [[ -z $_mntpoint ]]; then
-		_mntpoint="/kdumproot"
-	else
-		if [[ $_mntpoint == "/" ]]; then
-			_mntpoint="/sysroot"
-		else
-			_mntpoint="/kdumproot/$_mntpoint"
-		fi
-	fi
-
-	# strip duplicated "/"
-	echo $_mntpoint | tr -s "/"
-}
-
 kdump_get_persistent_dev()
 {
 	local dev="${1//\"/}"

--- a/kdumpctl
+++ b/kdumpctl
@@ -557,7 +557,7 @@ check_fs_modified()
 	fi
 
 	_target=$(get_block_dump_target)
-	_new_fstype=$(get_fs_type_from_target "$_target")
+	_new_fstype=$(get_fs_type_from_dump_target "$_target")
 	if [[ -z $_target ]] || [[ -z $_new_fstype ]]; then
 		derror "Dump target is invalid"
 		return 2
@@ -570,7 +570,7 @@ check_fs_modified()
 		return 2
 	fi
 
-	_new_mntpoint="$(get_kdump_mntpoint_from_target "$_target")"
+	_new_mntpoint="$(get_kdump_mntpoint_from_dump_target "$_target")"
 	_dracut_args=$(lsinitrd "$TARGET_INITRD" -f usr/lib/dracut/build-parameter.txt)
 	if [[ -z $_dracut_args ]]; then
 		dwarn "Warning: No dracut arguments found in initrd"
@@ -889,7 +889,7 @@ path_to_be_relabeled()
 		fi
 
 		if is_local_target; then
-			_mnt=$(get_mntpoint_from_target "${OPT[_target]}")
+			_mnt=$(get_mntpoint_from_dump_target "${OPT[_target]}")
 			if ! is_mounted "$_mnt"; then
 				return
 			fi

--- a/mkdumprd
+++ b/mkdumprd
@@ -75,9 +75,9 @@ to_mount()
 {
 	local _target=$1 _fstype=$2 _options=$3 _sed_cmd _new_mntpoint _pdev
 
-	_new_mntpoint=$(get_kdump_mntpoint_from_target "$_target")
-	_fstype="${_fstype:-$(get_fs_type_from_target "$_target")}"
-	_options="${_options:-$(get_mntopt_from_target "$_target")}"
+	_new_mntpoint=$(get_kdump_mntpoint_from_dump_target "$_target")
+	_fstype="${_fstype:-$(get_fs_type_from_dump_target "$_target")}"
+	_options="${_options:-$(get_mntopt_from_dump_target "$_target")}"
 	_options="${_options:-defaults}"
 
 	if [[ $_fstype == "nfs"* ]]; then
@@ -145,7 +145,7 @@ mkdir_save_path_ssh()
 #$1=dump target
 get_fs_size()
 {
-	df --output=avail "$(get_mntpoint_from_target "$1")/$SAVE_PATH" | tail -1
+	df --output=avail "$(get_mntpoint_from_dump_target "$1")/$SAVE_PATH" | tail -1
 }
 
 #Function: get_raw_size
@@ -218,9 +218,9 @@ check_user_configured_target()
 	local _target=$1 _cfg_fs_type=$2 _mounted
 	local _mnt _opt _fstype
 
-	_mnt=$(get_mntpoint_from_target "$_target")
-	_opt=$(get_mntopt_from_target "$_target")
-	_fstype=$(get_fs_type_from_target "$_target")
+	_mnt=$(get_mntpoint_from_dump_target "$_target")
+	_opt=$(get_mntopt_from_dump_target "$_target")
+	_fstype=$(get_fs_type_from_dump_target "$_target")
 
 	if [[ -n $_fstype ]]; then
 		# In case of nfs4, nfs should be used instead, nfs* options is deprecated in kdump.conf
@@ -310,7 +310,7 @@ handle_default_dump_target()
 
 	_save_path=$(get_bind_mount_source "$SAVE_PATH")
 	_target=$(get_target_from_path "$_save_path")
-	_mntpoint=$(get_mntpoint_from_target "$_target")
+	_mntpoint=$(get_mntpoint_from_dump_target "$_target")
 
 	SAVE_PATH=${_save_path##"$_mntpoint"}
 	add_mount "$_target"

--- a/mkdumprd
+++ b/mkdumprd
@@ -73,12 +73,12 @@ has_dracut_module()
 # caller should ensure $1 is valid and mounted in 1st kernel
 to_mount()
 {
-	local _target=$1 _fstype=$2 _options=$3 _sed_cmd _new_mntpoint _pdev
+	local _target=$1 _fstype=$2 _options=$3 _subvol=$4 _sed_cmd _new_mntpoint _pdev
 
-	_new_mntpoint=$(get_kdump_mntpoint_from_dump_target "$_target")
 	_fstype="${_fstype:-$(get_fs_type_from_dump_target "$_target")}"
 	_options="${_options:-$(get_mntopt_from_dump_target "$_target")}"
 	_options="${_options:-defaults}"
+	_new_mntpoint=$(get_kdump_mntpoint_from_dump_target "$_target" "$_subvol")
 
 	if [[ $_fstype == "nfs"* ]]; then
 		_pdev=$_target
@@ -301,7 +301,7 @@ add_mount()
 #handle the case user does not specify the dump target explicitly
 handle_default_dump_target()
 {
-	local _target
+	local _target _fstype _options
 	local _mntpoint
 
 	is_user_configured_dump_target && return
@@ -310,10 +310,13 @@ handle_default_dump_target()
 
 	_save_path=$(get_bind_mount_source "$SAVE_PATH")
 	_target=$(get_target_from_path "$_save_path")
-	_mntpoint=$(get_mntpoint_from_dump_target "$_target")
+	_fstype=$(get_fs_type_from_dump_target "$_target")
+	[[ $_fstype == "btrfs" ]] && _subvol=$(get_btrfs_subvol_from_mntpoint "$_save_path")
+	_mntpoint=$(get_mntpoint_from_dump_target "$_target" "$_subvol")
+	_options=$(get_mount_info OPTIONS target $_mntpoint)
 
 	SAVE_PATH=${_save_path##"$_mntpoint"}
-	add_mount "$_target"
+	add_mount "$_target" "$_fstype" "$_options" "$_subvol"
 	check_size fs "$_target"
 }
 


### PR DESCRIPTION
These patch set is aimed at improving bind mount and btrfs dump target.

The 1st patch resolved the same issue with #28.
The 2nd patch and the 3rd patch are doing some renaming work.
The 4th patch tries to resolve the btrfs issue by keeping subvol info when handling kdump target and block device.
For user configured btrfs dump target, currently just leave it as it is, so that it will always use the first subvol. maybe we can add a subvol option in /etc/kdump.conf in the future.