### PR TITLE
kdumpctl: deprecate --reboot for reset-creashkernel

### DIFF
--- a/crashkernel-howto.txt
+++ b/crashkernel-howto.txt
@@ -65,13 +65,13 @@ Reset using kdumpctl
 To make it easier to reset the `crashkernel=` kernel cmdline to this default
 value properly, `kdumpctl` also provides a sub-command:
 
-	`kdumpctl reset-crashkernel [--kernel=path_to_kernel] [--reboot]`
+	`kdumpctl reset-crashkernel [--kernel=path_to_kernel]`
 
 This command will reset the bootloader's kernel cmdline to the default value.
 It will also update bootloader config if the bootloader has a standalone config
 file. User will have to reboot the machine after this command to make it take
-effect if --reboot is not specified. For more details, please refer to the
-reset-crashkernel command in `man kdumpctl`.
+effect. For more details, please refer to the reset-crashkernel command in `man
+kdumpctl`.
 
 Reset manually
 --------------

--- a/kdumpctl
+++ b/kdumpctl
@@ -1491,6 +1491,10 @@ reset_crashkernel()
 				_grubby_kernel_path=$_val
 				;;
 			--reboot)
+				# --reboot option was deprecated with
+				# kdump-utils v1.0.45. Keep the code for now to
+				# not break any user setup.
+				dwarn "Option --reboot is deprecated and will be removed in the future."
 				_reboot=yes
 				;;
 			*)

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -53,7 +53,7 @@ based on the current kdump setup, and list some details of memory usage.
 .I get-default-crashkernel
 Return the default crashkernel value provided by kexec-tools.
 .TP
-.I reset-crashkernel [--kernel=path_to_kernel] [--reboot]
+.I reset-crashkernel [--kernel=path_to_kernel]
 Reset crashkernel to default value recommended by kexec-tools. If no kernel
 is specified, will reset KDUMP_KERNELVER if it's defined in /etc/sysconfig/kdump
 or the current running kernel's crashkernel value if KDUMP_KERNELVER is empty. You can
@@ -61,10 +61,6 @@ also specify --kernel=ALL and --kernel=DEFAULT which have the same meaning as
 grubby's kernel-path=ALL and kernel-path=DEFAULT. ppc64le supports FADump and
 supports an additional [--fadump=[on|off|nocma]] parameter to toggle FADump
 on/off.
-
-If the optional parameter [--reboot] is provided the system will automatically
-reboot for changes to take effect. If no changes were made to the kernel
-command line the reboot is omitted.
 
 Note: The memory requirements for kdump varies heavily depending on the
 used hardware and system configuration. Thus the recommended


### PR DESCRIPTION
The --reboot option for reset-crashkernel causes quite some confusion. Especially, there are different expectations when --reboot shall reboot the system. The current code only reboots the system when the crashkernel parameter was updated during this run. But there are other opinions, that --reboot shall also reboot the system if a previous run of `kdumpctl reset-crashkernel` updated the crashkernel parameter and no reboot occurred yet. While possible this would add extra complexity to the code. Neither the confusion nor the extra complexity are justified, given that --reboot only replaces a single additional command for the user.

Thus deprecate the --reboot option so it can be removed later on.