### PR TITLE
kdump.service: Replace ConditionKernelCommandLine with ExecCondition

### DIFF
--- a/kdump.service
+++ b/kdump.service
@@ -2,10 +2,10 @@
 Description=Crash recovery kernel arming
 After=network.target network-online.target remote-fs.target basic.target
 DefaultDependencies=no
-ConditionKernelCommandLine=crashkernel
 
 [Service]
 Type=oneshot
+ExecCondition=/bin/sh -c 'grep -q -e "crashkernel" -e "fadump" /proc/cmdline'
 ExecStart=/usr/bin/kdumpctl start
 ExecStop=/usr/bin/kdumpctl stop
 ExecReload=/usr/bin/kdumpctl reload


### PR DESCRIPTION
Commit 0084806493d0 ("kdump.service: use ConditionKernelCommandLine=crashkernel") added a condition based on the crashkernel kernel command line parameter to control the start of the kdump service.

While ConditionKernelCommandLine=crashkernel works well for kdump, it causes issues for fadump (specific to the PowerPC architecture), which also uses the same service unit. Unlike kdump, crashkernel kernel command-line is not mandatory for fadump.

Since ConditionKernelCommandLine doesn't support evaluating multiple kernel command line parameters with dependencies between them, it has been replaced with ExecCondition to resolve this limitation.

Now, if fadump is configured and the crashkernel parameter is NOT present in the kernel command line, kdump service will start.

Fixes: #35