### PR TITLE
kdump-lib-initramfs: Improve mount point retrieval logic

### DIFF
--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -103,8 +103,14 @@ get_fs_type_from_target()
 
 get_mntpoint_from_target()
 {
-	# --source is applied to ensure non-bind mount is returned
-	get_mount_info TARGET source "$1" -f
+	local _mntpoint
+	# get the first TARGET when SOURCE doesn't end with ].
+	# In most cases, a SOURCE ends with ] when fsroot or subvol exists.
+	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
+
+	# fallback to the old way when _mntpoint is empty.
+	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f )
+	echo $_mntpoint
 }
 
 is_ssh_dump_target()

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -205,7 +205,7 @@ get_bind_mount_source()
 
 	_fsroot=${_src#"${_src_nofsroot}"[}
 	_fsroot=${_fsroot%]}
-	_mnt=$(get_mount_info TARGET source "$_src_nofsroot" -f)
+	_mnt=$(get_mntpoint_from_target "$_src_nofsroot")
 
 	# for btrfs, _fsroot will also contain the subvol value as well, strip it
 	if [[ $_fstype == btrfs ]]; then

--- a/spec/kdump-lib-initramfs_spec.sh
+++ b/spec/kdump-lib-initramfs_spec.sh
@@ -38,4 +38,54 @@ Describe 'kdump-lib-initramfs'
 
 	End
 
+	Describe 'Test get_mntpoint_from_target'
+		findmnt() {
+			if [[ "$7" == 'eng.redhat.com:/srv/[nfs]' ]]; then
+				if [[ "$8" == "-f" ]]; then
+					printf '/mnt\n'
+				else
+					printf '/mnt %s\n' "$7"
+				fi
+			elif [[ "$7" == '[2620:52:0:a1:217:38ff:fe01:131]:/srv/[nfs]' ]]; then
+				if [[ "$8" == "-f" ]]; then
+					printf '/mnt\n'
+				else
+					printf '/mnt %s\n' "$7"
+				fi
+			elif [[ "$7" == '/dev/mapper/rhel[disk]' ]]; then
+				if [[ "$8" == "-f" ]]; then
+					printf '/\n'
+				else
+					printf '/ %s\n' "$7"
+				fi
+			elif [[ "$7" == '/dev/vda4' ]]; then
+				if [[ "$8" == "-f" ]]; then
+					printf '/var\n'
+				else
+					printf '/var %s[/ostree/deploy/default/var]\n/sysroot %s\n' "$7" "$7"
+				fi
+			fi
+		}
+
+		Context 'Given different cases'
+			# Test the following cases:
+			#  - IPv6 NFS target
+			#  - IPv6 NFS target also contain '[' in the export
+			#  - local dumping target that has '[' in the name
+			#  - has bind mint
+			Parameters
+				'eng.redhat.com:/srv/[nfs]' '/mnt'
+				'[2620:52:0:a1:217:38ff:fe01:131]:/srv/[nfs]' '/mnt'
+				'/dev/mapper/rhel[disk]' '/'
+				'/dev/vda4' '/sysroot'
+			End
+
+			It 'should handle all cases correctly'
+				When call get_mntpoint_from_target "$1"
+				The output should equal "$2"
+			End
+		End
+
+	End
+
 End


### PR DESCRIPTION
We use findmnt to find the real mount point by mount source, however, when there is a bind mount target, findmnt will give more than one results and what we actually want is the one without fsroot.

Will fallback to previous method if the $_mntpoint is empty.