### PR TITLE
Return the correct exit code of rebuild initrd

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -173,6 +173,7 @@ rebuild_kdump_initrd()
 
 rebuild_initrd()
 {
+	local _ret
 	dinfo "Rebuilding $TARGET_INITRD"
 
 	if [[ ! -w $(dirname "$TARGET_INITRD") ]]; then
@@ -185,8 +186,10 @@ rebuild_initrd()
 	else
 		rebuild_kdump_initrd
 	fi
+	_ret=$?
 
 	set_vmcore_creation_status 'clear' "$VMCORE_CREATION_STATUS"
+	return $_ret
 }
 
 #$1: the files to be checked with IFS=' '


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-63047
    
The exit code of rebuild_initrd() should be either of
rebuild_kdump/fadump_initrd(), rather than set_vmcore_creation_status(),
otherwise it will cause a regression when rebuild initrd fails.
    
Fixes: 88525ebf ("Introduce vmcore creation notification to kdump")
    
Signed-off-by: Tao Liu <ltao@redhat.com>