### PR TITLE
fadump: pass additional parameters for capture kernel

### DIFF
--- a/fadump-howto.txt
+++ b/fadump-howto.txt
@@ -319,7 +319,27 @@ Advanced Setups & Failure action:
 Kdump and fadump exhibit similar behavior in terms of setup & failure action.
 For fadump advanced setup related information see section "Advanced Setups" in
 "kexec-kdump-howto.txt" document. Refer to "Failure action" section in "kexec-
-kdump-howto.txt" document for fadump failure action related information.
+kdump-howto.txt" document for fadump failure action related information. Note
+that the below options from /etc/sysconfig/kdump have no relevance to fadump
+owing to the way it operates:
+
+-KDUMP_BOOTDIR
+-KDUMP_IMG
+-KDUMP_IMG_EXT
+-KEXEC_ARGS
+-KDUMP_KERNELVER
+-KDUMP_COMMANDLINE
+-KDUMP_COMMANDLINE_REMOVE
+-KDUMP_COMMANDLINE_APPEND
+
+Passing additional parameters to fadump capture kerenl
+
+-FADUMP_COMMANDLINE_APPEND
+
+If a powerpc system supports passing additional parameters, it would have the
+sysfs node '/sys/kernel/fadump/bootargs_append'. FADUMP_COMMANDLINE_APPEND
+allows us to append arguments to fadump capture kernel, further to parameters
+passed via the bootloader.
 
 Compression and filtering
 
@@ -331,11 +351,7 @@ Notes on rootfs mount:
 Dracut is designed to mount rootfs by default. If rootfs mounting fails it
 will refuse to go on. So fadump leaves rootfs mounting to dracut currently.
 We make the assumtion that proper root= cmdline is being passed to dracut
-initramfs for the time being. If you need modify "KDUMP_COMMANDLINE=" in
-/etc/sysconfig/kdump, you will need to make sure that appropriate root=
-options are copied from /proc/cmdline. In general it is best to append
-command line options using "KDUMP_COMMANDLINE_APPEND=" instead of replacing
-the original command line completely.
+initramfs for the time being.
 
 How to disable FADump:
 

--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -31,6 +31,10 @@ KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug quiet log_buf_len swio
 # after processed by KDUMP_COMMANDLINE_REMOVE
 KDUMP_COMMANDLINE_APPEND="irqpoll maxcpus=1 reset_devices novmcoredd cma=0 hugetlb_cma=0"
 
+# This variable lets us append arguments to fadump (powerpc) capture kernel,
+# further to the parameters passed via the bootloader.
+FADUMP_COMMANDLINE_APPEND=""
+
 # Any additional kexec arguments required.  In most situations, this should
 # be left empty
 #
@@ -97,6 +101,8 @@ ppc64le)
 		"hugepages hugepagesz slub_debug quiet log_buf_len swiotlb hugetlb_cma ignition.firstboot"
 	update_param KDUMP_COMMANDLINE_APPEND \
 		"irqpoll nr_cpus=1 noirqdistrib reset_devices cgroup_disable=memory numa=off udev.children-max=2 ehea.use_mcs=0 panic=10 kvm_cma_resv_ratio=0 transparent_hugepage=never novmcoredd hugetlb_cma=0"
+	update_param FADUMP_COMMANDLINE_APPEND \
+		"nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0 hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2"
 	;;
 s390x)
 	update_param KEXEC_ARGS "-s"

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -10,6 +10,7 @@ fi
 
 FADUMP_ENABLED_SYS_NODE="/sys/kernel/fadump/enabled"
 FADUMP_REGISTER_SYS_NODE="/sys/kernel/fadump/registered"
+FADUMP_APPEND_ARGS_SYS_NODE="/sys/kernel/fadump/bootargs_append"
 
 is_uki()
 {

--- a/kdumpctl
+++ b/kdumpctl
@@ -1115,6 +1115,15 @@ stop_kdump()
 
 reload_fadump()
 {
+	if "$FADUMP_APPEND_ARGS_SYS_NODE"; then
+		output=$(echo "${FADUMP_COMMANDLINE_APPEND}" > "$FADUMP_APPEND_ARGS_SYS_NODE")
+		if [ $? -eq 0 ]; then
+			output=$(cat "$FADUMP_APPEND_ARGS_SYS_NODE")
+			dinfo "fadump: additional parameters '$output' for capture kernel"
+		else
+			dwarn "WARNING: failed to setup additional parameters for fadump capture kernel ($output)"
+		fi
+	fi
 	if echo 1 > "$FADUMP_REGISTER_SYS_NODE"; then
 		dinfo "fadump: re-registered successfully"
 		return 0


### PR DESCRIPTION
Since kernel commit 3416c9daa6b13 ("powerpc/fadump: pass additional parameters when fadump is active"), fadump supports passing additional parameters to dump capture kernel. Leverage that support here to pass additional parameters to dump capture kernel.

Also, update fadump-howto.txt to make clear on the options that are not relevant for fadump in /etc/sysconfig/kdump

The default bootargs to append for fadump capture kernel boot are chosen with the intent to optimize resources and reduce memory footprint in dump capture environment.