### PR TITLE
Re-introduce vmcore creation notification to kdump

### DIFF
--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -312,22 +312,11 @@ do_final_action() {
 }
 
 do_dump() {
-    if [ -d /vmcorestatus ]; then
-        _vmcore_creation_status="/vmcorestatus/$VMCORE_CREATION_STATUS"
-    else
-        _vmcore_creation_status="/sysroot/$VMCORE_CREATION_STATUS"
-    fi
-
-    set_vmcore_creation_status 'clear' "$_vmcore_creation_status"
-
     eval "$DUMP_INSTRUCTION"
     _ret=$?
 
     if [ $_ret -ne 0 ]; then
-        set_vmcore_creation_status 'fail' "$_vmcore_creation_status"
         derror "saving vmcore failed"
-    else
-        set_vmcore_creation_status 'success' "$_vmcore_creation_status"
     fi
 
     return $_ret

--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -51,10 +51,6 @@ KDUMP_IMG="vmlinuz"
 #What is the images extension.  Relocatable kernels don't have one
 KDUMP_IMG_EXT=""
 
-# Enable vmcore creation notification by default, disable by setting
-# VMCORE_CREATION_NOTIFICATION=""
-VMCORE_CREATION_NOTIFICATION="yes"
-
 # Logging is controlled by following variables in the first kernel:
 #   - @var KDUMP_STDLOGLVL - logging level to standard error (console output)
 #   - @var KDUMP_SYSLOGLVL - logging level to syslog (by logger command)

--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -51,6 +51,10 @@ KDUMP_IMG="vmlinuz"
 #What is the images extension.  Relocatable kernels don't have one
 KDUMP_IMG_EXT=""
 
+# Enable vmcore creation notification by default, disable by setting
+# VMCORE_CREATION_NOTIFICATION=""
+VMCORE_CREATION_NOTIFICATION="yes"
+
 # Logging is controlled by following variables in the first kernel:
 #   - @var KDUMP_STDLOGLVL - logging level to standard error (console output)
 #   - @var KDUMP_SYSLOGLVL - logging level to syslog (by logger command)

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -9,7 +9,6 @@ KDUMP_CONFIG_FILE="/etc/kdump.conf"
 FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
 LVM_CONF="/etc/lvm/lvm.conf"
-VMCORE_CREATION_STATUS="/var/crash/vmcore-creation.status"
 
 # Read kdump config in well formated style
 kdump_read_conf()
@@ -177,36 +176,4 @@ kdump_get_ip_route()
 kdump_get_ip_route_field()
 {
 	echo "$1" | sed -n -e "s/^.*\<$2\>\s\+\(\S\+\).*$/\1/p"
-}
-
-# $1: success/fail/clear
-# $2: status_file
-set_vmcore_creation_status()
-{
-	_status=$1
-	_status_file=$2
-	_dir=$(dirname "$_status_file")
-
-	[[ -d "$_dir" ]] || mkdir -p "$_dir"
-
-	_mnt_op=$(get_mount_info OPTIONS target "$_dir" -f)
-	case $_mnt_op in
-	ro*)
-		dinfo "remounting the vmcore status target in rw mode."
-		mount -o remount,rw "$(findmnt -n -o TARGET --target $_dir)"
-		;;
-	esac
-
-	case "$_status" in
-		success | fail)
-			dinfo "saving vmcore status file to $_status_file"
-			echo  "$_status $(date +%s)" > "$_status_file"
-			;;
-		clear)
-			rm -f "$_status_file"
-			;;
-		*)
-			return
-	esac
-	sync -f "$_dir"
 }

--- a/kdumpctl
+++ b/kdumpctl
@@ -14,6 +14,7 @@ KDUMP_INITRD=""
 TARGET_INITRD=""
 #kdump shall be the default dump mode
 DEFAULT_DUMP_MODE="kdump"
+VMCORE_CREATION_STATUS="/var/lib/kdump/vmcore-creation.status"
 
 # Some default values in case /etc/sysconfig/kdump doesn't include
 KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug"
@@ -45,8 +46,10 @@ if ! dlog_init; then
 fi
 
 KDUMP_TMPDIR=$(mktemp --tmpdir -d kdump.XXXX)
+TMPMNT="$KDUMP_TMPDIR/target"
 trap '
     ret=$?;
+    is_mounted $TMPMNT && umount -f $TMPMNT;
     rm -rf "$KDUMP_TMPDIR"
     exit $ret;
     ' EXIT
@@ -185,6 +188,11 @@ rebuild_initrd()
 	else
 		rebuild_kdump_initrd
 	fi
+
+	_ret=$?
+
+	set_vmcore_creation_status 'clear'
+	return $_ret
 }
 
 #$1: the files to be checked with IFS=' '
@@ -1674,6 +1682,170 @@ _should_reset_crashkernel() {
 	[[ $(kdump_get_conf_val auto_reset_crashkernel) != no ]] && systemctl is-enabled kdump &> /dev/null
 }
 
+set_kdump_test_id()
+{
+	local _id=$1
+
+	KDUMP_COMMANDLINE_APPEND+=" $_id "
+	reload >& /dev/null
+
+	if [[ "$?" -ne 0 ]]; then
+		derror "Set kdump test id fail."
+		exit 1
+	fi
+}
+
+# $1: success/fail/pending/manual/clear
+# $2: test id
+set_vmcore_creation_status()
+{
+	local _status=$1
+	local _kdump_test_id
+	_dir=$(dirname "$VMCORE_CREATION_STATUS")
+
+	[[ -d "$_dir" ]] || mkdir -p "$_dir"
+	[[ -w "$_dir" ]] || chmod +w "$_dir"
+
+	case "$_status" in
+		pending)
+			_kdump_test_id="kdump_test_id=$(date +%s-%N)"
+			set_kdump_test_id "$_kdump_test_id"
+			echo  "$_status $_kdump_test_id" > "$VMCORE_CREATION_STATUS"
+			;;
+		success | fail | manual)
+			sed -E -i "s/^\w+/$_status/" "$VMCORE_CREATION_STATUS"
+			;;
+		clear)
+			rm -f "$VMCORE_CREATION_STATUS"
+			;;
+		*)
+			return
+	esac
+	sync -f "$_dir"
+}
+
+fetch_status()
+{
+	local _test_id="$1" _mnt
+	local  _status
+
+	is_raw_dump_target && return 2
+
+	_status="${OPT[path]}/kdump-test-$_test_id/vmcore-creation.status"
+
+	if is_nfs_dump_target || is_local_target; then
+		_mnt=$(get_mntpoint_from_target "${OPT[_target]}")
+		if [[ -z "$_mnt" ]] || ! is_mounted "$_mnt"; then
+			mkdir -p $TMPMNT
+			mount "${OPT[_target]}" "$TMPMNT" -t "${OPT[_fstype]}" -o defaults || \
+				{ dwarn "Failed to mount ${OPT[_target]}" && return 2; }
+			_mnt="$TMPMNT"
+		fi
+		_status="$_mnt/$_status"
+	elif is_ssh_dump_target; then
+		scp -i "${OPT[sshkey]}" -o BatchMode=yes \
+			"${OPT[_target]}:$_status" \
+			"$KDUMP_TMPDIR"
+		case "$?" in
+			0)
+				# success
+				;;
+			1)
+				# file not found
+				return 1
+				;;
+			255)
+				# no connection to host
+				return 2
+		esac
+		_status="$KDUMP_TMPDIR/vmcore-creation.status"
+	fi
+
+	[[ -f "$_status" ]] || return 1
+	grep -q "success" "$_status" && return 0 || return 1
+}
+
+check_vmcore_creation_status()
+{
+	local _status _test_id _timestamp _status_date
+
+	[[ ${VMCORE_CREATION_NOTIFICATION,,} == "yes" ]] || return
+
+	[[ "$DEFAULT_DUMP_MODE" == "kdump" ]] || return
+
+	if [[ ! -s "$VMCORE_CREATION_STATUS" ]]; then
+		dwarn "Notice: No vmcore creation test performed!"
+		return
+	fi
+
+	[[ "${#OPT[@]}" -eq 0 ]] && { parse_config || return; }
+
+	read -r _status _test_id < "$VMCORE_CREATION_STATUS"
+	_test_id=${_test_id#*=}
+	_timestamp=${_test_id%-*}
+	_status_date=$(date -d "@$_timestamp")
+
+	if [[ "$_status" == "pending" ]]; then
+		fetch_status "$_test_id"
+		case "$?" in
+		0)
+			_status="success"
+			;;
+		1)
+			_status="fail"
+			;;
+		*)
+			_status="manual"
+			;;
+		esac
+		set_vmcore_creation_status "$_status"
+	fi
+
+	case "$_status" in
+		success)
+			dinfo "Notice: Last successful vmcore creation on $_status_date"
+			;;
+		fail)
+			dwarn "Notice: Last NOT successful vmcore creation on $_status_date"
+			;;
+		manual)
+			dwarn "Notice: Require manual check for kdump test of $_status_date"
+			;;
+		*)
+			derror "Unknown test status: $_status"
+			;;
+	esac
+}
+
+kdump_test()
+{
+	if ! is_kernel_loaded "$DEFAULT_DUMP_MODE"; then
+		derror "Kdump needs be operational before test."
+		exit 1
+	fi
+
+	if [[ ! "$DEFAULT_DUMP_MODE" == "kdump" ]]; then
+		derror "Only kdump is supported for test."
+		exit 1
+	fi
+
+	if [[ ! "$1" == "--force" ]]; then
+		read -p "DANGER!!! Will perform a kdump test by crashing the system, proceed? (y/N): " input
+		case $input in
+		[Yy] )
+			dinfo "Start kdump test..."
+			;;
+		* )
+			dinfo "Operation cancelled."
+			exit 0
+			;;
+		esac
+	fi
+
+	set_vmcore_creation_status 'pending'
+	echo c > /proc/sysrq-trigger
+}
+
 main()
 {
 	# Determine if the dump mode is kdump or fadump
@@ -1705,6 +1877,7 @@ main()
 			EXIT_CODE=3
 			;;
 		esac
+		check_vmcore_creation_status
 		exit $EXIT_CODE
 		;;
 	reload)

--- a/kdumpctl
+++ b/kdumpctl
@@ -173,7 +173,6 @@ rebuild_kdump_initrd()
 
 rebuild_initrd()
 {
-	local _ret
 	dinfo "Rebuilding $TARGET_INITRD"
 
 	if [[ ! -w $(dirname "$TARGET_INITRD") ]]; then
@@ -186,10 +185,6 @@ rebuild_initrd()
 	else
 		rebuild_kdump_initrd
 	fi
-	_ret=$?
-
-	set_vmcore_creation_status 'clear' "$VMCORE_CREATION_STATUS"
-	return $_ret
 }
 
 #$1: the files to be checked with IFS=' '
@@ -1064,7 +1059,6 @@ start()
 	start_dump || return
 
 	dinfo "Starting kdump: [OK]"
-	check_vmcore_creation_status
 	return 0
 }
 
@@ -1680,63 +1674,6 @@ _should_reset_crashkernel() {
 	[[ $(kdump_get_conf_val auto_reset_crashkernel) != no ]] && systemctl is-enabled kdump &> /dev/null
 }
 
-check_vmcore_creation_status()
-{
-	local _status _timestamp _status_date
-
-	[[ ${VMCORE_CREATION_NOTIFICATION,,} == "yes" ]] || return
-
-	if [[ ! -s $VMCORE_CREATION_STATUS ]]; then
-		dwarn "Notice: No vmcore creation test performed!"
-		return
-	fi
-
-	read -r _status _timestamp < "$VMCORE_CREATION_STATUS"
-	_status_date="$(date -d "@$_timestamp")"
-
-	if [[ "$_status" == "success" ]]; then
-		dinfo "Notice: Last successful vmcore creation on $_status_date"
-	else
-		dwarn "Notice: Last NOT successful vmcore creation on $_status_date"
-	fi
-}
-
-kdump_test()
-{
-	local _dir
-
-	if ! is_kernel_loaded "$DEFAULT_DUMP_MODE"; then
-		derror "Kdump needs be operational before test."
-		exit 1
-	fi
-
-	_dir=$(dirname "$VMCORE_CREATION_STATUS")
-	if ! [[ -d "$_dir" ]]; then
-		derror "Vmcore status dir $_dir not exist."
-		exit 1
-	fi
-
-	if ! lsblk $(get_mount_info SOURCE target "$_dir") > /dev/null; then
-		derror "$VMCORE_CREATION_STATUS must on local drive"
-		exit 1
-	fi
-
-	if [[ ! "$1" == "--force" ]]; then
-		read -p "DANGER!!! Will perform a kdump test by crashing the system, proceed? (y/N): " input
-		case $input in
-		[Yy] )
-			dinfo "Start kdump test..."
-			;;
-		* )
-			dinfo "Operation cancelled."
-			exit 0
-			;;
-		esac
-	fi
-	set_vmcore_creation_status 'clear' "$VMCORE_CREATION_STATUS"
-	echo c > /proc/sysrq-trigger
-}
-
 main()
 {
 	# Determine if the dump mode is kdump or fadump
@@ -1768,7 +1705,6 @@ main()
 			EXIT_CODE=3
 			;;
 		esac
-		check_vmcore_creation_status
 		exit $EXIT_CODE
 		;;
 	reload)
@@ -1803,6 +1739,10 @@ main()
 		shift
 		reset_crashkernel "$@"
 		;;
+	test)
+		shift
+		kdump_test "$@"
+		;;
 	_reset-crashkernel-after-update)
 		if _should_reset_crashkernel; then
 			reset_crashkernel_after_update
@@ -1812,10 +1752,6 @@ main()
 		if _should_reset_crashkernel; then
 			reset_crashkernel_for_installed_kernel "$2"
 		fi
-		;;
-	test)
-		shift
-		kdump_test "$@"
 		;;
 	*)
 		dinfo $"Usage: $0 {estimate|start|stop|status|restart|reload|rebuild|reset-crashkernel|propagate|showmem|test}"

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -66,16 +66,6 @@ Note: The memory requirements for kdump varies heavily depending on the
 used hardware and system configuration. Thus the recommended
 crashkernel might not work for your specific setup. Please test if
 kdump works after resetting the crashkernel value.
-.TP
-.I test [--force]
-Test the kdump by actually trigger the system crash & dump, and check if a
-vmcore can really be generated successfully based on current config and
-environment. After system reboot back to normal, check the test result
-by "kdumpctl status".
-
-If the optional parameter [--force] is provided, there will be no interact
-before triggering the system crash. Dangerous though, this option is meant
-for automation testing.
 
 .SH "SEE ALSO"
 .BR kdump.conf (5),

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -66,7 +66,16 @@ Note: The memory requirements for kdump varies heavily depending on the
 used hardware and system configuration. Thus the recommended
 crashkernel might not work for your specific setup. Please test if
 kdump works after resetting the crashkernel value.
+.TP
+.I test [--force]
+Test the kdump by actually trigger the system crash & dump, and check if a
+vmcore can really be generated successfully based on current config and
+environment. After system reboot back to normal, check the test result
+by "kdumpctl status". Note, fadump is not supported.
 
+If the optional parameter [--force] is provided, there will be no confirmation
+before triggering the system crash. Dangerous though, this option is meant
+for automation testing.
 .SH "SEE ALSO"
 .BR kdump.conf (5),
 .BR mkdumprd (8)

--- a/mkdumprd
+++ b/mkdumprd
@@ -71,10 +71,9 @@ has_dracut_module()
 # caller should ensure $1 is valid and mounted in 1st kernel
 to_mount()
 {
-	local _target=$1 _fstype=$2 _options=$3 _new_mntpoint=$4
-	local _sed_cmd _pdev
+	local _target=$1 _fstype=$2 _options=$3 _sed_cmd _new_mntpoint _pdev
 
-	_new_mntpoint="${_new_mntpoint:-$(get_kdump_mntpoint_from_target "$_target")}"
+	_new_mntpoint=$(get_kdump_mntpoint_from_target "$_target")
 	_fstype="${_fstype:-$(get_fs_type_from_target "$_target")}"
 	_options="${_options:-$(get_mntopt_from_target "$_target")}"
 	_options="${_options:-defaults}"
@@ -426,17 +425,6 @@ if ! is_fadump_capable; then
 	if fips-mode-setup --is-enabled 2> /dev/null; then
 		dracut_args+=(--add-device "$(findmnt -n -o SOURCE --target /boot)")
 	fi
-fi
-
-status_target=$(get_target_from_path $(dirname "$VMCORE_CREATION_STATUS"))
-
-if [[ $(get_root_fs_device) != "$status_target" ]]; then
-	new_mntpoint=$(echo /vmcorestatus/$(get_mntpoint_from_target "$status_target") \
-		| tr -s "/")
-	add_mount "$status_target" "" "" "$new_mntpoint"
-elif ! is_fadump_capable && \
-     ! [[ ${dracut_args[@]} == *"$(kdump_get_persistent_dev $status_target)"* ]]; then
-	add_mount "$status_target"
 fi
 
 # Use kdump managed dracut profile.


### PR DESCRIPTION
    Motivation
    ==========
    
    People may forget to recheck to ensure kdump works, which as a result, a
    possibility of no vmcores generated after a real system crash. It is
    unexpected for kdump.
    
    It is highly recommended people to test kdump after any system modification,
    such as:
    
    a. after kernel patching or whole yum update, as it might break something
       on which kdump is dependent, maybe due to introduction of any new bug etc.
    b. after any change at hardware level, maybe storage, networking,
       firmware upgrading etc.
    c. after implementing any new application, like which involves 3rd party modules
       etc.
    
    Though these exceed the range of kdump, however a simple vmcore creation
    status notification is good to have for now.
    
    Design
    ======
    
    Kdump currently will check any relating files/fs/drivers modified before
    determine if initrd should rebuild when (re)start. A rebuild is an
    indicator of such modification, and kdump need to be tested. This will
    clear the vmcore creation status specified in $VMCORE_CREATION_STATUS,
    and as a result, a notification of vmcore creation test will be
    outputted.
    
    To test kdump, there is an entry for doing that by "kdumpctl test". It
    will generate a timestamp string as the ID of the current test, along
    with a "pending" status in $VMCORE_CREATION_STATUS, then a real crash &
    dump process will be triggered.
    
    After system reboot back to normal, a vmcore creation check will start at
    "kdumpctl (re)start/status", and will report the results as
    success/fail/manual status to users.
    
    To achieve that, program will first check the status in $VMCORE_CREATION_STATUS.
    If "pending" status if found, which means the test result is
    undetermined and need a retrive from remote/local dump folder. Then if test
    id is found in the dump folder and vmcore is complete, then "pending"
    would be overwritten by "success", which indicates a successful kdump
    test. If test id is found in the dump folder but vmcore is incomplete,
    then it is a "fail" kdump test. If no test id is found, then it is a "manual"
    status, which indicates users should check the test results manually.
    
    If $VMCORE_CREATION_STATUS is already success/fail/manual status, it indicates
    the test result has already been determined, so the program will not access
    the remote/local dump folder again. This can limite any unnecessary
    access to dump target, shorten the time consumption.
    
    User should check for the root cause of fail/manual status when get
    reports.
    
    $VMCORE_CREATION_STATUS is used for recording the vmcore creation status of
    the current env. The format is like:
    
       <status> kdump_test_id=<timestamp sec>-<timestamp nanosec>
    e.g:
       success kdump_test_id=1729823462-938751820
    
    Which means, there has been a successful kdump test at
    $(date -d "@1729823462") timestamp for the current env. Timestamp
    nanosec is only meaningful for uniquify id string.
    
    Difference
    ==========
    Previously there is one commit 88525ebf ("Introduce vmcore creation
    notification to kdump") merged and addressing the same issue, but
    implemented differently:
    
    The prev one:
    Save the $VMCORE_CREATION_STATUS to local drive during the 2nd kernel
    dumping. If vmcore dumping target is different from $VMCORE_CREATION_STATUS's
    drive, then the latter one need to be mounted in 2nd kernel.
    
    This one:
    Save the $VMCORE_CREATION_STATUS to local drive only in 1nd kernel, that
    is, the test result is retrived after 2nd kernel dumping. So it doesn't
    load or mount other drive in 2nd kernel.
    
    The advantage:
    Extra mounting in 2nd kernel will introduce higher risk of failure,
    as a result, lower the success of vmcore dumping, which is
    unaccepted. So keep the code for 2nd kernel as simple is preferred.
    
    Usage
    =====
    [root@localhost ~]# kdumpctl restart
    kdump: kexec: unloaded kdump kernel
    kdump: Stopping kdump: [OK]
    kdump: kexec: loaded kdump kernel
    kdump: Starting kdump: [OK]
    kdump: Notice: No vmcore creation test performed!
    
    [root@localhost ~]# kdumpctl status
    kdump: Kdump is operational
    kdump: Notice: No vmcore creation test performed!
    
    [root@localhost ~]# kdumpctl test
    
    [root@localhost ~]# cat /var/lib/kdump/vmcore-creation.status
    pending kdump_test_id=1729823462-938751820
    
    [root@localhost ~]# kdumpctl status
    kdump: Kdump is operational
    kdump: Notice: Last successful vmcore creation on Fri Oct 25 02:31:02 AM UTC 2024
    
    [root@localhost ~]# cat /var/lib/kdump/vmcore-creation.status
    success kdump_test_id=1729823462-938751820
    
    [root@localhost ~]# kdumpctl restart
    kdump: kexec: unloaded kdump kernel
    kdump: Stopping kdump: [OK]
    kdump: kexec: loaded kdump kernel
    kdump: Starting kdump: [OK]
    kdump: Notice: Last successful vmcore creation on Fri Oct 25 02:31:02 AM UTC 2024
    
    Note: the notification for kdumpctl (re)start/status can be disabled by
    setting VMCORE_CREATION_NOTIFICATION in /etc/sysconfig/kdump. And fadump
    is NOT supported for this feature.
    
    Signed-off-by: Tao Liu <ltao@redhat.com>
