### PR TITLE
Let %post scriptlet always exit successfully

### DIFF
--- a/kdump-utils.spec
+++ b/kdump-utils.spec
@@ -56,6 +56,10 @@ servicelog_notify --remove --command=/usr/lib/kdump/kdump-migrate-action.sh 2>/d
 servicelog_notify --add --command=/usr/lib/kdump/kdump-migrate-action.sh --match='refcode="#MIGRATE" and serviceable=0' --type=EVENT --method=pairs_stdin >/dev/null
 %endif
 
+# RPM scriptlet should always return 0. Otherwise it can break
+# installs/upgrades/erases.
+:
+
 
 %postun
 %systemd_postun_with_restart kdump.service


### PR DESCRIPTION
Resolves: https://github.com/rhkdump/kdump-utils/issues/56

Currently, kdump-utils fails to upgrade to
kdump-utils-1.0.48-1.fc42.ppc64le on ppc64le FCOS as servicelog_notify failed to be executed,

    # journalctl -t 'rpm-ostree(kdump-utils.post)'
    ... rpm-ostree(kdump-utils.post)[2376]: + touch /etc/kdump.conf
    ... rpm-ostree(kdump-utils.post)[2376]: + servicelog_notify --remove --command=/usr/lib/kdump/kdump-migrate-action.sh
    ... rpm-ostree(kdump-utils.post)[2376]: + servicelog_notify --add --command=/usr/lib/kdump/kdump-migrate-action.sh '--match=refcode="#MIGRATE" and serviceable=0' --type=EVENT --method=pairs_stdin
    ... rpm-ostree(kdump-utils.post)[2382]: No such file or directory

RPM scriplets should always return 0 status code to avoid breaking installs/upgrades/erases [1].

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/

Fixes: ea0b3afa ("Replace remaining occurrences of kexec-tools with kdump-utils")