### PR TITLE
CI: build coreOS with kdump RPM and run tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,45 @@
+// Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
+
+properties([
+    // abort previous runs when a PR is updated to save resources
+    disableConcurrentBuilds(abortPrevious: true)
+])
+
+
+buildPod(runAsUser: 0, memory: "2Gi", cpu: "2") {
+      checkout scm
+      stage("Install packit") {
+        shwrap("""
+          dnf install packit -y
+        """)
+      }
+      stage("Build kdump RPM") {
+        // note: coreos upstream CI only run on x86 so we hardcode the architecture
+        shwrap("""
+          packit build locally --release-suffix coreos.tests
+          mv x86_64/kdump-utils*coreos.tests*.rpm ./kdump-coreos-ci.rpm
+        """)
+      }
+      // make it easy for anyone to download the RPMs
+      archiveArtifacts 'kdump-coreos-ci.rpm'
+      stash includes: 'kdump-coreos-ci.rpm', name: 'kdump-rpm'
+}
+
+// Build FCOS with the kdump rpm
+cosaPod {
+
+   stage("Build FCOS") {
+       unstash 'kdump-rpm'
+       shwrap("""
+         coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+         mv kdump-coreos-ci.rpm overrides/rpm
+         cosa fetch --with-cosa-overrides
+         cosa build
+       """)
+     }
+
+   // the kdump kola tests
+    stage("Kola kdump tests") {
+      kola(cosaDir: "${env.WORKSPACE}", extraArgs: '\\*kdump\\*', skipUpgrade: true, skipBasicScenarios: true)
+    }
+}


### PR DESCRIPTION
This will uses Fedora CoreOS jenkins instance to run tests on PRs for this repo. It simply uses packit to create an RPM and build an FCOS VM image with it, then run some kdump tests. 

Example of a run : https://jenkins-coreos-ci.apps.ocp.fedoraproject.org/blue/organizations/jenkins/kdump-upstream/detail/enable-coreos-ci/5/pipeline

Here are the tests being run : 
- [local dump](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/tests/kola/kdump/crash/test.sh)
- [over SSH](https://github.com/coreos/coreos-assembler/blob/17c1cc8ea2463a111074c06bb916fcfbfd0964ba/mantle/kola/tests/ignition/kdump.go#L120)
- [over NFS](https://github.com/coreos/coreos-assembler/pull/3922). Note this one is not active, waiting on dracut 104.

Note that you need to be a members of `coreos` or `openshift` orgs to cancel or restart jobs. Maybe we need to work a better way around that.

A couple items needs to be done to fully complete this : 
- [ ] add github user `coreosbot` as an admin to this repo : enable github hooks to report the results on PRs
- [x] Merge [this PR](https://github.com/coreos/coreos-ci/pull/74) to enable it on upstream CI

See [there](https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md) for more details. 

Also see https://issues.redhat.com/browse/RHEL-70438