### PR TITLE
Enable xtrace for mkdumprd when debug=1

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -6,6 +6,8 @@
 # Written by Cong Wang <amwang@redhat.com>
 #
 
+[[ -n $debug ]] && set -x
+
 if [[ -f /etc/sysconfig/kdump ]]; then
 	. /etc/sysconfig/kdump
 fi


### PR DESCRIPTION
To debug issues like [1] [2], it's helpful to enable xtrace.

[1] https://issues.redhat.com/browse/RHEL-35885
[2] https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169