### PR TITLE
99-kdump.conf: Omit nouveau module

### DIFF
--- a/99-kdump.conf
+++ b/99-kdump.conf
@@ -1,3 +1,4 @@
 dracutmodules=''
 add_dracutmodules=' kdumpbase '
 omit_dracutmodules=' rdma plymouth resume ifcfg earlykdump '
+omit_drivers+=' nouveau amdgpu '


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-52304

The nouveau module provides no significant utility in second kernel, and it introduces firmware that occupies approximately 38MB of memory, which is critical in the constrained environment of kdump. Omit it helps reduce memory usage and optimize the crash recovery process.