### PR TITLE
tests: fix occasional LVM2-thinp test failures

### DIFF
--- a/tests/setup/lvm2_thinp/test.sh
+++ b/tests/setup/lvm2_thinp/test.sh
@@ -30,6 +30,9 @@ EOF
     lvcreate -V 300M -T $VG/$LV_THINPOOL -n $LV_VOLUME
     mkfs.ext4 /dev/$VG/$LV_VOLUME
     mount /dev/$VG/$LV_VOLUME /mnt
+    # Prevent an empty /etc/lvm/devices/system.devices file after a kernel
+    # panic which will cause failure of pvscan
+    rm -f /etc/lvm/devices/system.devices
     mkdir -p /mnt/$VMCORE_PATH
 
     cat << EOF > /etc/kdump.conf


### PR DESCRIPTION
Somehow LVM2-thinp test fails occasionally. It turns out the test fails
because /etc/lvm/devices/system.devices somehow becomes empty file after
a kernel panic,

    [root@client ~]# journalctl -b0 |grep vdb
    Aug 02 08:10:52 localhost kernel: virtio_blk virtio2: [vdb] 2097152 512-byte logical blocks (1.07 GB/1.00 GiB)
    Aug 02 08:10:54 client lvm[712]: /dev/vdb excluded by devices file (checking PVID).

    [root@client ~]# cat /etc/lvm/devices/system.devices
    # empty result

    [root@client ~]# pvscan -vvv
      /dev/vdb: Skipping (deviceid)

"sync -f /etc/lvm/devices/system.devices" doesn't work for this case. So
simply delete it to prevent an empty /etc/lvm/devices/system.devices. An
empty system.devices will filter out the LVM device (dev/vdb) [1].

Note the failure of this flaky test can happen 1/15 times,

    log_dir=logs_dir
    mkdir -p $log_dir
    for i in {01..15}; do
      if tmt run  --environment KDUMP_UTILS_RPM=kdump-utils plan --name /plans/lvm2_thinp &> $log_dir/$i.log; then
        echo $i success
      else
        echo $i failure
        break
      fi
    done

[1] https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/limiting-lvm-device-visibility-and-usage_configuring-and-managing-logical-volumes?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#disabling-the-system-devices-file_the-lvm-devices-file