### PR TITLE
powerpc: fix early exit from udev on hotplug event for fadump

### DIFF
--- a/98-kexec.rules.ppc64
+++ b/98-kexec.rules.ppc64
@@ -17,7 +17,7 @@ LABEL="kdump_reload_mem"
 
 # Don't re-register fadump if /sys/kernel/fadump/hotplug_ready sysfs is set to 1.
 
-RUN+="/bin/sh -c '/usr/bin/systemctl is-active kdump.service || exit 0; ! test -f /sys/kernel/fadump/hotplug_ready || cat /sys/kernel/fadump/hotplug_ready | grep 1 || exit 0; /usr/bin/systemd-run --quiet --no-block /usr/lib/udev/kdump-udev-throttler'"
+RUN+="/bin/sh -c '/usr/bin/systemctl is-active kdump.service || exit 0; ! test -f /sys/kernel/fadump/hotplug_ready || cat /sys/kernel/fadump/hotplug_ready | grep 0 || exit 0; /usr/bin/systemd-run --quiet --no-block /usr/lib/udev/kdump-udev-throttler'"
 
 GOTO="kdump_reload_end"
 


### PR DESCRIPTION
Sysfs /sys/kernel/fadump/hotplug_ready contains 1 if hotplug is supported by fadump.

Now to exit early the RUN command should grep 0 from /sys/kernel/fadump/hotplug_ready instead of 1.

Fix it by updating RUN command.

Fixes: b4e3d3724cf3 ("fadump/udev: do not re-register fadump if kernel hotplug ready")