### PR TITLE
99-kdump.conf: Omit hwdb dracut module

### DIFF
--- a/99-kdump.conf
+++ b/99-kdump.conf
@@ -1,4 +1,4 @@
 dracutmodules=''
 add_dracutmodules=' kdumpbase '
-omit_dracutmodules=' rdma plymouth resume ifcfg earlykdump '
+omit_dracutmodules=' hwdb rdma plymouth resume ifcfg earlykdump '
 omit_drivers+=' nouveau amdgpu '


### PR DESCRIPTION
The hwdb (udev hardware database) file `/etc/udev/hwdb.bin` is currently included in the initramfs, taking up approximately 13MB of space. This is a significant size for kdump initramfs, which may lead more OOM issues.

Certain advanced device initializations that rely on hwdb (e.g., custom keyboard mappings, specific touchpad configurations) may not work in the kdump environment.

However, kdump do not require hwdb in the most cases, as critical devices like storage, network, and basic input devices are typically handled by standard udev rules and kernel drivers.

This change prioritizes reducing initramfs size over retaining hardware database functionality, as the latter is rarely critical in the kdump environment.

Resolves: https://issues.redhat.com/browse/RHEL-57731