### PR TITLE
Bring up the network before Open vSwitch bridge

### DIFF
--- a/tests/plans/main.fmf
+++ b/tests/plans/main.fmf
@@ -9,17 +9,19 @@ provision:
 
 
 prepare:
+  - name: Use custom mirror
+    # Run this task before task essential-requires
+    order: 30
+    how: shell
+    script:
+      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora*.repo || true
+      - dnf config-manager --set-disabled fedora-cisco-openh264 || true
+
   # Set root password to log in as root in the console
   - name: Set root password
     how: shell
     script:
       - echo root:kdump | chpasswd
-
-  - name: Use custom mirror
-    how: shell
-    script:
-      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora*.repo || true
-      - dnf config-manager --set-disabled fedora-cisco-openh264 || true
 
   - name: Install built RPM
     how: install

--- a/tests/plans/nfs_ovs.fmf
+++ b/tests/plans/nfs_ovs.fmf
@@ -1,0 +1,39 @@
+summary: Kdump NFS dumping tests
+discover:
+  - name: Set up crashkernel
+    how: fmf
+    test:
+     - setup/default_crashkernel
+    where:
+      - client
+  - name: Set up NFS server
+    how: fmf
+    test:
+     - setup/nfs_server
+    where:
+      - server
+  - name: Set up OVS network
+    how: fmf
+    test:
+     - setup/ovs_network
+    where:
+      - client
+  - name: Setup NFS client
+    how: fmf
+    test:
+     # For tmt, nfs means nfs*, so use nfs$ to exclude nfs_early
+     - setup/network_client/nfs$
+    where:
+      - client
+  - name: Panic kernel
+    how: fmf
+    test:
+     - /setup/trigger_crash
+    where:
+      - client
+  - name: Check vmcore
+    how: fmf
+    test:
+     - /tests/check_vmcore/nfs
+    where:
+      - server

--- a/tests/setup/ovs_network/main.fmf
+++ b/tests/setup/ovs_network/main.fmf
@@ -1,0 +1,9 @@
+summary: Set up Open vSwitch bridge network
+test: ./test.sh
+framework: shell
+require:
+ - /usr/bin/ovs-vsctl
+ - NetworkManager-ovs
+ - nmap-ncat
+ - jq
+

--- a/tests/setup/ovs_network/test.sh
+++ b/tests/setup/ovs_network/test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -eux
+
+ovs_configure_script=/usr/local/bin/configure-ovs.sh
+
+extract_configure-ovs-script() {
+   local _script_url
+
+   _script_url=https://github.com/openshift/machine-config-operator/raw/refs/heads/master/templates/common/_base/files/configure-ovs-network.yaml
+
+   if curl -sL $_script_url | grep -A2000 '#!/bin/bash' > "$ovs_configure_script";  then
+       chmod +x "$ovs_configure_script"
+   else
+       return 1
+   fi
+}
+
+create_bond_network() {
+    local _ifname
+
+    _ifname=$(ip route show default | awk '{print $5}') || return 1
+    nmcli con add type bond ifname bond0
+    nmcli con add type ethernet ifname "$_ifname" master bond0
+    nmcli con up "bond-slave-$_ifname"
+}
+
+
+systemctl enable --now openvswitch
+# restart NM so the ovs plugin can be activated
+systemctl restart NetworkManager
+
+mkdir -p /etc/ovnk
+echo bond0 > /etc/ovnk/iface_default_hint
+
+extract_configure-ovs-script
+create_bond_network
+"$ovs_configure_script" OVNKubernetes
+
+# make the connections persistent
+cp /run/NetworkManager/system-connections/* /etc/NetworkManager/system-connections/


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-75547

Currently, kdump tries to bring up the same network as in 1st kernel as
we assume if the same network works in the 1st kernel, there is no
reason it won't work in 1st kernel.

But for Open vSwitch (OVS) bridge, there are two challenges,
1. Extra memory requirement
   For example, crashkernel=260M will be needed for OVS bridge while
   only crashkernel=192M is sufficient for default network for F40 cloud
   image.

2. A bit complex dependencies
   An extra dracut module is needed to install dependent executables,
   helper scripts, configuration files and a NetworkManager plugin.

To avoid the above challenges, we try to bring up the network before OVS
bridge instead. OVS bridge is set up by ovs-configuration.service
[1][2], we can assume the previous network has worked.

When ovs-configuration.service is started, it will bring down the
original connection profiles. So we should go through the inactive
connection profiles to find out what connection profiles is for bringing
up the physical network interface.

```
How to test this patch with the help of configure-ovs.sh?
=========================================================

1. Extract configure-ovs.sh from [2]

2. Install necessary packages for configure-ovs.sh
    dnf install openvswitch -yq
    dnf install NetworkManager-ovs nmap-ncat -yq

    systemctl enable --now openvswitch

    # restart NM so the ovs plugin can be activated
    systemctl restart NetworkManager

3. Assume the network interface used for creating an Ovs bridge is
   "ens2", use configure-ovs.sh to create an Ovs bridge,

    interface=ens2
    mkdir -p /etc/ovnk
    echo $interface > /etc/ovnk/iface_default_hint
    bash configure-ovs.sh OVNKubernetes

4. (Optional) If you want to make the created Ovs bridge survive a
   reboot, simply make the created NM connections created by
   configure-ovs.sh persist,

    cp /run/NetworkManager/system-connections/* /etc/NetworkManager/system-connections/

If you need to create an Ovs bridge on top of a bonding network, use the
following commands for step 3,

    nmcli con add type bond ifname bond0
    nmcli con add type ethernet ifname eth0 master bond0
    nmcli con add type ethernet ifname eth1 master bond0

    echo bond0 > /etc/ovnk/iface_default_hint
    bash configure-ovs.sh OVNKubernetes
````

Note
1. For RHEL9, openvswitch package needs to installed from another repo,
    cat << 'EOF' > /etc/yum.repos.d/ovs.repo
    [rhosp-rhel-9-fdp-cdn]
    name=Red Hat Enterprise Linux Fast Datapath $releasever - $basearch cdn
    baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os/
    enabled=1
    gpgcheck=0
    EOF

    dnf install openvswitch3.3 -yq


[1] https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/units/ovs-configuration.service.yaml
[2] https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml