### PR TITLE
tests: set up custom mirror before essential-requires

### DIFF
--- a/tests/plans/main.fmf
+++ b/tests/plans/main.fmf
@@ -9,17 +9,19 @@ provision:
 
 
 prepare:
+  - name: Use custom mirror
+    # Run this task before task essential-requires
+    order: 30
+    how: shell
+    script:
+      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora*.repo || true
+      - dnf config-manager --set-disabled fedora-cisco-openh264 || true
+
   # Set root password to log in as root in the console
   - name: Set root password
     how: shell
     script:
       - echo root:kdump | chpasswd
-
-  - name: Use custom mirror
-    how: shell
-    script:
-      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora*.repo || true
-      - dnf config-manager --set-disabled fedora-cisco-openh264 || true
 
   - name: Install built RPM
     how: install


### PR DESCRIPTION
By default, the embedded task essential-requires runs before all prepare tasks,
        queued prepare task #1: essential-requires on client and server
        queued prepare task #2: Set root password on client and server
        queued prepare task #3: Use custom mirror on client and server
        queued prepare task #4: Install built RPM on client

And it takes 13m to finish the SSH dumping tests. By running task "Use custom mirror" early, the test could be finished within 3m.