### PR TITLE
Check /proc/sys/crypto/fips_enabled to tell if FIPS has been enabled

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -424,7 +424,7 @@ if ! is_fadump_capable; then
 
 	dracut_args+=(--no-hostonly-default-device)
 
-	if fips-mode-setup --is-enabled 2> /dev/null; then
+	if [[ $(cat /proc/sys/crypto/fips_enabled) == 1  ]]; then
 		dracut_args+=(--add-device "$(findmnt -n -o SOURCE --target /boot)")
 	fi
 fi


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-75539

A proposal [1] has been submitted to remove fips-mode-setup from Fedora
42. And we are suggested to tell if FIPS has been enabled by check if /proc/sys/crypto/fips_enabled has 1.

[1] https://fedoraproject.org/wiki/Changes/RemoveFipsModeSetup#Feedback
[2] https://developers.redhat.com/articles/2024/02/27/handling-fips-mode-upstream-projects-rhel#