### PR TITLE
Enable tests against rawhide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         strategy:
             matrix:
                 fedora_version: [
-                        "40",
+                        "40", "rawhide"
                 ]
             fail-fast: false
         steps:

--- a/tests/plans/local.fmf
+++ b/tests/plans/local.fmf
@@ -1,6 +1,9 @@
 summary: Kdump local dumping
+enabled: true
 # Disable this plan due to https://bugzilla.redhat.com/show_bug.cgi?id=2270423
-enabled: false
+adjust:
+    enabled: false
+    when: distro == fedora
 discover:
     how: fmf
     test:

--- a/tests/plans/nfs.fmf
+++ b/tests/plans/nfs.fmf
@@ -1,4 +1,8 @@
 summary: Kdump NFS dumping tests
+enabled: true
+adjust:
+    enabled: false
+    when: distro > fedora-40
 discover:
   - name: Set up crashkernel
     how: fmf

--- a/tests/plans/nfs_early.fmf
+++ b/tests/plans/nfs_early.fmf
@@ -1,4 +1,8 @@
 summary: Kdump NFS early dumping tests
+enabled: true
+adjust:
+    enabled: false
+    when: distro > fedora-40
 discover:
   - name: Set up crashkernel
     how: fmf

--- a/tests/plans/ssh.fmf
+++ b/tests/plans/ssh.fmf
@@ -1,4 +1,8 @@
 summary: Kdump SSH dumping tests
+enabled: true
+adjust:
+  enabled: false
+  when: distro == fedora-rawhide
 discover:
   - name: Set up crashkernel
     how: fmf

--- a/tests/tests/check_vmcore/test.sh
+++ b/tests/tests/check_vmcore/test.sh
@@ -5,7 +5,7 @@ has_valid_vmcore_dir() {
     local vmcore_dir
     local vmcore="<invalid>"
 
-    MAX_WAIT_TIME=300
+    MAX_WAIT_TIME=10
     _waited=0
     while [ $_waited -le $MAX_WAIT_TIME ]; do
         if vmcore_dir=$(find "$path/"* -maxdepth 0 2> /dev/null); then

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -27,4 +27,4 @@ if [[ ! -f $rpm_path ]]; then
 	echo "Failed to find built kdump-utils rpm ($rpm_path doesn't eixst)"
 fi
 
-cd tests && tmt run --environment CUSTOM_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/fedora --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"
+cd tests && tmt --context distro="fedora-${fedora_version}" run --environment CUSTOM_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/fedora --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -5,6 +5,8 @@ set -ex
 [[ -d ${0%/*} ]] && cd "${0%/*}"/../
 
 fedora_version=${1:-40}
+mirror=${2:-https://mirrors.tuna.tsinghua.edu.cn/fedora}
+[[ $fedora_version == rawhide ]] && mirror=https://mirrors.sjtug.sjtu.edu.cn/fedora/linux
 
 dist_abbr=.fc$fedora_version
 
@@ -27,4 +29,4 @@ if [[ ! -f $rpm_path ]]; then
 	echo "Failed to find built kdump-utils rpm ($rpm_path doesn't eixst)"
 fi
 
-cd tests && tmt --context distro="fedora-${fedora_version}" run --environment CUSTOM_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/fedora --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"
+cd tests && tmt --context distro="fedora-${fedora_version}" run --environment CUSTOM_MIRROR=$mirror --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/KEX-203

By running kdump-utils tests against Fedora rawhide, we can catch regressions earlier. This will also cover latest dracut as kdump heavily depends on dracut.

