### PR TITLE
kdump-lib.sh: rounded up the total_mem to 128M in get_system_size

### DIFF
--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -801,8 +801,11 @@ PROC_IOMEM=/proc/iomem
 #get system memory size i.e. memblock.memory.total_size in the unit of GB
 get_system_size()
 {
-	sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
-	echo $(( (sum) / 1024 / 1024 / 1024))
+	local _mem_size_mb _sum
+	_sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
+	_mem_size_mb=$(( (_sum) / 1024 / 1024 ))
+	# rounding up the total_size to 128M to align with kernel code kernel/crash_reserve.c
+	echo $(((_mem_size_mb + 127) / 128 * 128 / 1024 ))
 }
 
 # Return the recommended size for the reserved crashkernel memory

--- a/spec/kdump-lib_spec.sh
+++ b/spec/kdump-lib_spec.sh
@@ -12,17 +12,19 @@ Describe 'kdump-lib'
 
 		AfterAll 'cleanup'
 
-		ONE_GIGABYTE='000000-3fffffff : System RAM'
+		# 1000MB per block
+		MEMORY_BLOCK='000000-3e800000 : System RAM'
 		Parameters
-			1
-			3
+			1 1
+			3 3
+			6 5
 		End
 
 		It 'should return correct system RAM size'
 			echo -n >"$PROC_IOMEM"
-			for _ in $(seq 1 "$1"); do echo "$ONE_GIGABYTE" >>"$PROC_IOMEM"; done
+			for _ in $(seq 1 "$1"); do echo "$MEMORY_BLOCK" >>"$PROC_IOMEM"; done
 			When call get_system_size
-			The output should equal "$1"
+			The output should equal "$2"
 		End
 
 	End


### PR DESCRIPTION
The kernel code to calculate reserving size rounded up the total_mem because
usually the memblock usable mem size is smaller than the physical dimm memory
size:
        total_mem = roundup(total_mem, SZ_128M);

This patch is aimed to align with the kernel's behavior. A machine showing
4000MB of total memory will be treated as having 4G instead of 3G memory.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2306493

Signed-off-by: Lichen Liu <lichliu@redhat.com>