### PR TITLE
kdumpctl: improve do_estimate by considering unpacked initramfs size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     container: docker.io/fedora:latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo dnf install -y make dracut grubby hostname
+      - run: sudo dnf install -y make dracut grubby hostname gawk
       - run: curl -L -O https://github.com/shellspec/shellspec/archive/latest.tar.gz && tar -xzf latest.tar.gz
       - run: cd shellspec-latest && sudo make install
       - run: shellspec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,13 @@ jobs:
       - run: dnf install shellcheck -y
       # Currently, for kdump-utils, there is need for shellcheck to require
       # the sourced file to give correct warnings about the checked file
-      - run: shellcheck -x *.sh spec/*.sh kdumpctl mk*dumprd
+      - run: shellcheck -x *.sh  kdumpctl mk*dumprd
       - run: shellcheck -x dracut/*/*.sh
       - run: shellcheck -x tests/*/*/*.sh tools/*.sh
+      # disable the follow checks for unit tests
+      # - 2317: to use shellspec directives like Context, When and etc.
+      # - 2288, 2215: to use test data like -o, 'eng.redhat.com:/srv/[nfs]' in parametrized tests
+      - run: shellcheck -e 2317,2288,2215 -x spec/*.sh
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -606,7 +606,7 @@ kdump_test_set_status() {
     [ -n "$KDUMP_TEST_STATUS" ] || return
 
     case "$_status" in
-        success|fail) ;;
+        success | fail) ;;
         *)
             derror "Unknown test status $_status"
             return 1
@@ -622,7 +622,7 @@ kdump_test_set_status() {
         ssh -q $_ssh_opts "$_ssh_host" "echo $_status kdump_test_id=$KDUMP_TEST_ID > $KDUMP_TEST_STATUS" \
             || return 1
     else
-	_target=$(echo "$DUMP_INSTRUCTION" | awk '{print $2}')
+        _target=$(echo "$DUMP_INSTRUCTION" | awk '{print $2}')
 
         mkdir -p "$_target/$KDUMP_PATH" || return 1
         echo "$_status kdump_test_id=$KDUMP_TEST_ID" > "$_target/$KDUMP_TEST_STATUS"

--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -617,8 +617,10 @@ kdump_test_set_status() {
         _ssh_opts="-i $SSH_KEY_LOCATION -o BatchMode=yes -o StrictHostKeyChecking=yes"
         _ssh_host=$(echo "$DUMP_INSTRUCTION" | awk '{print $3}')
 
+        # shellcheck disable=SC2086 # need to word-split $_ssh_opts
         ssh -q $_ssh_opts "$_ssh_host" "mkdir -p ${KDUMP_TEST_STATUS%/*}" \
             || return 1
+        # shellcheck disable=SC2086 # need to word-split $_ssh_opts
         ssh -q $_ssh_opts "$_ssh_host" "echo $_status kdump_test_id=$KDUMP_TEST_ID > $KDUMP_TEST_STATUS" \
             || return 1
     else

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -11,7 +11,10 @@ _save_kdump_netifs() {
 }
 
 _get_kdump_netifs() {
-    echo -n "${!unique_netifs[@]} ${!ovs_unique_netifs[@]}"
+    local -a _all_netifs
+
+    _all_netifs=("${!unique_netifs[@]}" "${!ovs_unique_netifs[@]}")
+    echo -n "${_all_netifs[@]}"
 }
 
 kdump_module_init() {

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -340,7 +340,7 @@ _install_nmconnections_before_ovs() {
             derror "Failed to install the .nmconnection for $_nic_name"
             exit 1
         fi
-    done <<<"$(nmcli --get-values filename,ACTIVE connection show | grep "no$")"
+    done <<< "$(nmcli --get-values filename,ACTIVE connection show | grep "no$")"
 }
 
 kdump_install_nmconnections() {

--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -29,7 +29,7 @@ KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug quiet log_buf_len swio
 
 # This variable lets us append arguments to the current kdump commandline
 # after processed by KDUMP_COMMANDLINE_REMOVE
-KDUMP_COMMANDLINE_APPEND="irqpoll maxcpus=1 reset_devices novmcoredd cma=0 hugetlb_cma=0"
+KDUMP_COMMANDLINE_APPEND="irqpoll maxcpus=1 reset_devices novmcoredd cma=0 hugetlb_cma=0 kfence.sample_interval=0"
 
 # This variable lets us append arguments to fadump (powerpc) capture kernel,
 # further to the parameters passed via the bootloader.

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -11,13 +11,13 @@
 dest_dir="/tmp"
 
 if [ -n "$1" ]; then
-    dest_dir=$1
+	dest_dir=$1
 fi
 
 systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-    mkdir -p $kdump_wants
-    ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p $kdump_wants
+	ln -sf $systemd_dir/network-online.target $kdump_wants/
 fi

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -18,6 +18,6 @@ systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-	mkdir -p $kdump_wants
-	ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p "$kdump_wants"
+	ln -sf $systemd_dir/network-online.target "$kdump_wants"/
 fi

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -3,7 +3,9 @@
 # More details about systemd generator:
 # http://www.freedesktop.org/wiki/Software/systemd/Generators/
 
+# shellcheck source=SCRIPTDIR/kdump-lib.sh
 . /usr/lib/kdump/kdump-lib-initramfs.sh
+# shellcheck source=SCRIPTDIR/kdump-logger.sh
 . /usr/lib/kdump/kdump-logger.sh
 
 # If invokded with no arguments for testing purpose, output to /tmp to

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -37,6 +37,7 @@ is_mounted()
 # $2: mount source type
 # $3: mount source
 # $4: extra args
+# shellcheck disable=SC2086 # $4 means extra args which nees to word-splitted
 get_mount_info()
 {
 	__kdump_mnt=$(findmnt -k -n -r -o "$1" "--$2" "$3" $4)
@@ -109,7 +110,7 @@ get_mntpoint_from_target()
 
 	# fallback to the old way when _mntpoint is empty.
 	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f)
-	echo $_mntpoint
+	echo "$_mntpoint"
 }
 
 is_ssh_dump_target()

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -108,7 +108,7 @@ get_mntpoint_from_target()
 	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
 
 	# fallback to the old way when _mntpoint is empty.
-	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f )
+	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f)
 	echo $_mntpoint
 }
 

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -105,13 +105,12 @@ get_fs_type_from_target()
 
 get_mntpoint_from_target()
 {
-	local _mntpoint
 	# get the first TARGET when SOURCE doesn't end with ].
 	# In most cases, a SOURCE ends with ] when fsroot or subvol exists.
 	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
 
 	# fallback to the old way when _mntpoint is empty.
-	[[ -n "$_mntpoint" ]] || _mntpoint=$(get_mount_info TARGET source "$1" -f)
+	[ -n "$_mntpoint" ] || _mntpoint=$(get_mount_info TARGET source "$1" -f)
 	echo "$_mntpoint"
 }
 

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -4,10 +4,12 @@
 # not be the default shell. Any code added must be POSIX compliant.
 
 DEFAULT_PATH="/var/crash/"
+# shellcheck disable=SC2034
 DEFAULT_SSHKEY="/root/.ssh/kdump_id_rsa"
 KDUMP_CONFIG_FILE="/etc/kdump.conf"
-FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
+# shellcheck disable=SC2034
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
+# shellcheck disable=SC2034
 LVM_CONF="/etc/lvm/lvm.conf"
 
 # Read kdump config in well formated style

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -5,6 +5,7 @@
 if [[ ${__SOURCED__:+x} ]]; then
 	. ./kdump-lib-initramfs.sh
 else
+	# shellcheck source=SCRIPTDIR/kdump-lib-initramfs.sh
 	. /lib/kdump/kdump-lib-initramfs.sh
 fi
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -997,6 +997,7 @@ _crashkernel_add()
 # get default crashkernel
 # $1 dump mode, if not specified, dump_mode will be judged by is_fadump_capable
 # $2 kernel-release, if not specified, got by _get_kdump_kernel_version
+# shellcheck disable=SC2120 # kdumpctl will call this func with an argument
 kdump_get_arch_recommend_crashkernel()
 {
 	local _arch _ck_cmdline _dump_mode

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -8,9 +8,13 @@ else
 	. /lib/kdump/kdump-lib-initramfs.sh
 fi
 
+# shellcheck disable=SC2034
 FADUMP_ENABLED_SYS_NODE="/sys/kernel/fadump/enabled"
 FADUMP_REGISTER_SYS_NODE="/sys/kernel/fadump/registered"
+# shellcheck disable=SC2034
 FADUMP_APPEND_ARGS_SYS_NODE="/sys/kernel/fadump/bootargs_append"
+# shellcheck disable=SC2034
+FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
 
 is_uki()
 {
@@ -663,8 +667,10 @@ prepare_kdump_bootinfo()
 	if [[ ! -w $KDUMP_BOOTDIR ]]; then
 		var_target_initrd_dir="/var/lib/kdump"
 		mkdir -p "$var_target_initrd_dir"
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$var_target_initrd_dir/$kdump_initrd_base"
 	else
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$KDUMP_BOOTDIR/$kdump_initrd_base"
 	fi
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -245,7 +245,7 @@ get_kdump_mntpoint_from_target()
 	fi
 
 	# strip duplicated "/"
-	echo $_mntpoint | tr -s "/"
+	echo "$_mntpoint" | tr -s "/"
 }
 
 kdump_get_persistent_dev()

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -792,6 +792,8 @@ prepare_cmdline()
 
 	# This is a workaround on AWS platform. Always remove irqpoll since it
 	# may cause the hot-remove of some pci hotplug device.
+	# shellcheck disable=SC2001 # \< and \> are word boundary markers which
+	# doesn't exist in bash parameter expansion
 	is_aws_aarch64 && out=$(echo "$out" | sed -e "s/\<irqpoll\>//")
 
 	# Always disable gpt-auto-generator as it hangs during boot of the

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -18,7 +18,7 @@ is_uki()
 
 	img="$1"
 
-	[[ -f "$img" ]] || return
+	[[ -f $img ]] || return
 	[[ "$(objdump -a "$img" 2> /dev/null)" =~ pei-(x86-64|aarch64-little) ]] || return
 	objdump -h -j .linux "$img" &> /dev/null
 }
@@ -41,7 +41,7 @@ is_aws_aarch64()
 
 is_sme_or_sev_active()
 {
-	journalctl -q --dmesg --grep "^Memory Encryption Features active: AMD (SME|SEV)$" >/dev/null 2>&1
+	journalctl -q --dmesg --grep "^Memory Encryption Features active: AMD (SME|SEV)$" > /dev/null 2>&1
 }
 
 has_command()
@@ -523,7 +523,7 @@ prepare_kdump_kernel()
 
 	# Use BOOT_IMAGE as reference if possible, strip the GRUB root device prefix in (hd0,gpt1) format
 	boot_img="$(grep -P -o '^BOOT_IMAGE=(\S+)' /proc/cmdline | sed "s/^BOOT_IMAGE=\((\S*)\)\?\(\S*\)/\2/")"
-	if [[ "$boot_img" == *"$kdump_kernelver" ]]; then
+	if [[ $boot_img == *"$kdump_kernelver" ]]; then
 		boot_imglist="$boot_img $boot_imglist"
 	fi
 
@@ -549,10 +549,10 @@ parse_kver_from_path()
 {
 	local _img _kver
 
-	[[ -z "$1" ]] && return
+	[[ -z $1 ]] && return
 
 	_img=$1
-	BLS_ENTRY_TOKEN=$(</etc/machine-id)
+	BLS_ENTRY_TOKEN=$(< /etc/machine-id)
 
 	# Fedora standard installation, i.e. $BOOT/vmlinuz-<version>
 	_kver=${_img##*/vmlinuz-}
@@ -585,13 +585,13 @@ _get_kdump_kernel_version()
 {
 	local _version _version_nondebug
 
-	if [[ -n "$KDUMP_KERNELVER" ]]; then
+	if [[ -n $KDUMP_KERNELVER ]]; then
 		echo "$KDUMP_KERNELVER"
 		return
 	fi
 
 	_version=$(uname -r)
-	if [[ ! "$_version" =~ [+|-]debug$ ]]; then
+	if [[ ! $_version =~ [+|-]debug$ ]]; then
 		echo "$_version"
 		return
 	fi
@@ -627,7 +627,7 @@ prepare_kdump_bootinfo()
 	fi
 
 	# For 64k variant, e.g. vmlinuz-5.14.0-327.el9.aarch64+64k-debug
-	if [[ "$KDUMP_KERNEL" == *"+debug" || "$KDUMP_KERNEL" == *"64k-debug" ]]; then
+	if [[ $KDUMP_KERNEL == *"+debug" || $KDUMP_KERNEL == *"64k-debug" ]]; then
 		dwarn "Using debug kernel, you may need to set a larger crashkernel than the default value."
 	fi
 
@@ -718,11 +718,10 @@ prepare_cmdline()
 
 	in=${1:-$(< /proc/cmdline)}
 	while read -r opt val; do
-		[[ -n "$opt" ]] || continue
+		[[ -n $opt ]] || continue
 		remove[$opt]=1
 	done <<< "$(_cmdline_parse "$2")"
 	append=$3
-
 
 	# These params should always be removed
 	remove[crashkernel]=1
@@ -751,10 +750,10 @@ prepare_cmdline()
 	remove[iscsi_initiator]=1
 
 	while read -r opt val; do
-		[[ -n "$opt" ]] || continue
-		[[ -n "${remove[$opt]}" ]] && continue
+		[[ -n $opt ]] || continue
+		[[ -n ${remove[$opt]} ]] && continue
 
-		if [[ -n "$val" ]]; then
+		if [[ -n $val ]]; then
 			out+="$opt=$val "
 		else
 			out+="$opt "
@@ -764,7 +763,7 @@ prepare_cmdline()
 	out+="$append "
 
 	id=$(get_bootcpu_apicid)
-	if [[ -n "${id}" ]]; then
+	if [[ -n ${id} ]]; then
 		out+="disable_cpu_apicid=$id "
 	fi
 
@@ -803,9 +802,9 @@ get_system_size()
 {
 	local _mem_size_mb _sum
 	_sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
-	_mem_size_mb=$(( (_sum) / 1024 / 1024 ))
+	_mem_size_mb=$(((_sum) / 1024 / 1024))
 	# rounding up the total_size to 128M to align with kernel code kernel/crash_reserve.c
-	echo $(((_mem_size_mb + 127) / 128 * 128 / 1024 ))
+	echo $(((_mem_size_mb + 127) / 128 * 128 / 1024))
 }
 
 # Return the recommended size for the reserved crashkernel memory
@@ -829,8 +828,8 @@ get_recommend_size()
 
 		# aka. 102400T
 		end=${end:-104857600}
-		[[ "$end_unit" == T ]] && end=$((end * 1024))
-		[[ "$start_unit" == T ]] && start=$((start * 1024))
+		[[ $end_unit == T ]] && end=$((end * 1024))
+		[[ $start_unit == T ]] && start=$((start * 1024))
 
 		if [[ $mem_size -ge $start ]] && [[ $mem_size -lt $end ]]; then
 			echo "$size"
@@ -854,7 +853,10 @@ has_aarch64_smmu()
 	ls /sys/devices/platform/arm-smmu-* 1> /dev/null 2>&1
 }
 
-is_memsize() { [[ "$1" =~ ^[+-]?[0-9]+[KkMmGgTtPbEe]?$ ]]; }
+is_memsize()
+{
+	[[ $1 =~ ^[+-]?[0-9]+[KkMmGgTtPbEe]?$ ]]
+}
 
 # range defined for crashkernel parameter
 # i.e. <start>-[<end>]
@@ -873,32 +875,31 @@ to_bytes()
 	is_memsize "$_s" || return 1
 
 	case "${_s: -1}" in
-		K|k)
-			_s=${_s::-1}
-			_s="$((_s * 1024))"
-			;;
-		M|m)
-			_s=${_s::-1}
-			_s="$((_s * 1024 * 1024))"
-			;;
-		G|g)
-			_s=${_s::-1}
-			_s="$((_s * 1024 * 1024 * 1024))"
-			;;
-		T|t)
-			_s=${_s::-1}
-			_s="$((_s * 1024 * 1024 * 1024 * 1024))"
-			;;
-		P|p)
-			_s=${_s::-1}
-			_s="$((_s * 1024 * 1024 * 1024 * 1024 * 1024))"
-			;;
-		E|e)
-			_s=${_s::-1}
-			_s="$((_s * 1024 * 1024 * 1024 * 1024 * 1024 * 1024))"
-			;;
-		*)
-			;;
+	K | k)
+		_s=${_s::-1}
+		_s="$((_s * 1024))"
+		;;
+	M | m)
+		_s=${_s::-1}
+		_s="$((_s * 1024 * 1024))"
+		;;
+	G | g)
+		_s=${_s::-1}
+		_s="$((_s * 1024 * 1024 * 1024))"
+		;;
+	T | t)
+		_s=${_s::-1}
+		_s="$((_s * 1024 * 1024 * 1024 * 1024))"
+		;;
+	P | p)
+		_s=${_s::-1}
+		_s="$((_s * 1024 * 1024 * 1024 * 1024 * 1024))"
+		;;
+	E | e)
+		_s=${_s::-1}
+		_s="$((_s * 1024 * 1024 * 1024 * 1024 * 1024 * 1024))"
+		;;
+	*) ;;
 	esac
 	echo "$_s"
 }
@@ -912,14 +913,14 @@ memsize_add()
 	b=$(to_bytes "$2") || return 1
 	i=0
 
-	(( a += b ))
+	((a += b))
 	while :; do
-		[[ $(( a / 1024 )) -eq 0 ]] && break
-		[[ $(( a % 1024 )) -ne 0 ]] && break
-		[[ $(( ${#units[@]} - 1 )) -eq $i ]] && break
+		[[ $((a / 1024)) -eq 0 ]] && break
+		[[ $((a % 1024)) -ne 0 ]] && break
+		[[ $((${#units[@]} - 1)) -eq $i ]] && break
 
-		(( a /= 1024 ))
-		(( i += 1 ))
+		((a /= 1024))
+		((i += 1))
 	done
 
 	echo "${a}${units[$i]}"
@@ -932,10 +933,10 @@ _crashkernel_parse()
 
 	ck="$1"
 
-	if [[ "$ck" == *@* ]]; then
+	if [[ $ck == *@* ]]; then
 		offset="@${ck##*@}"
 		ck=${ck%@*}
-	elif [[ "$ck" == *,high ]] || [[ "$ck" == *,low ]]; then
+	elif [[ $ck == *,high ]] || [[ $ck == *,low ]]; then
 		offset=",${ck##*,}"
 		ck=${ck%,*}
 	else
@@ -943,8 +944,8 @@ _crashkernel_parse()
 	fi
 
 	while read -d , -r entry; do
-		[[ -n "$entry" ]] || continue
-		if [[ "$entry" == *:* ]]; then
+		[[ -n $entry ]] || continue
+		if [[ $entry == *:* ]]; then
 			range=${entry%:*}
 			size=${entry#*:}
 		else
@@ -969,20 +970,20 @@ _crashkernel_add()
 	ret=""
 
 	while IFS=';' read -r size range offset; do
-		if [[ -n "$offset" ]]; then
+		if [[ -n $offset ]]; then
 			ret="${ret%,}$offset"
 			break
 		fi
 
-		[[ -n "$size" ]] || continue
-		if [[ -n "$range" ]]; then
+		[[ -n $size ]] || continue
+		if [[ -n $range ]]; then
 			is_memrange "$range" || return 1
 			ret+="$range:"
 		fi
 
 		size=$(memsize_add "$size" "$delta") || return 1
 		ret+="$size,"
-	done < <( _crashkernel_parse "$ck")
+	done < <(_crashkernel_parse "$ck")
 
 	echo "${ret%,}"
 }
@@ -995,7 +996,7 @@ kdump_get_arch_recommend_crashkernel()
 	local _arch _ck_cmdline _dump_mode
 	local _delta=0
 
-	if [[ -z "$1" ]]; then
+	if [[ -z $1 ]]; then
 		if is_fadump_capable; then
 			_dump_mode=fadump
 		else
@@ -1015,7 +1016,7 @@ kdump_get_arch_recommend_crashkernel()
 
 		# Base line for 4K variant kernel. The formula is based on x86 plus extra = 64M
 		_ck_cmdline="2G-4G:256M,4G-64G:320M,64G-:576M"
-		if [[ -z "$2" ]]; then
+		if [[ -z $2 ]]; then
 			_running_kernel=$(_get_kdump_kernel_version)
 		else
 			_running_kernel=$2
@@ -1071,7 +1072,7 @@ get_luks_crypt_dev()
 
 	[[ -b /dev/block/$1 ]] || return 1
 
-	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" | \
+	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" |
 		sed -n -E "s/^TYPE=(.*)$/\1/p")
 	[[ $_type == "crypto_LUKS" ]] && echo "$1"
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -407,10 +407,10 @@ is_kernel_loaded()
 #
 get_bootcpu_apicid()
 {
-	awk '                                                       \
-        BEGIN { CPU = "-1"; }                                   \
-        $1=="processor" && $2==":"      { CPU = $NF; }          \
-        CPU=="0" && /^apicid/           { print $NF; }          \
+	awk '
+        BEGIN { CPU = "-1"; }
+        $1=="processor" && $2==":"      { CPU = $NF; }
+        CPU=="0" && /^apicid/           { print $NF; }
         ' \
 		/proc/cpuinfo
 }

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -97,8 +97,11 @@ dlog_init()
 		kdump_stdloglvl=0
 		kdump_kmsgloglvl=0
 	else
+		# shellcheck disable=SC2153 # KDUMP_*LOGLVL is read from /etc/kdump/sysconfig by file that source kdump-logger.sh
 		kdump_stdloglvl=$KDUMP_STDLOGLVL
+		# shellcheck disable=SC2153
 		kdump_sysloglvl=$KDUMP_SYSLOGLVL
+		# shellcheck disable=SC2153
 		kdump_kmsgloglvl=$KDUMP_KMSGLOGLVL
 	fi
 

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -141,12 +141,12 @@ dlog_init()
 
 	kdump_maxloglvl=0
 	for _dlog_lvl in $kdump_stdloglvl $kdump_sysloglvl $kdump_kmsgloglvl; do
-		[ $_dlog_lvl -gt $kdump_maxloglvl ] && kdump_maxloglvl=$_dlog_lvl
+		[ "$_dlog_lvl" -gt "$kdump_maxloglvl" ] && kdump_maxloglvl=$_dlog_lvl
 	done
 	readonly kdump_maxloglvl
 	export kdump_maxloglvl
 
-	if [ $kdump_stdloglvl -lt 4 ] && [ $kdump_kmsgloglvl -lt 4 ] && [ $kdump_sysloglvl -lt 4 ]; then
+	if [ "$kdump_stdloglvl" -lt 4 ] && [ "$kdump_kmsgloglvl" -lt 4 ] && [ "$kdump_sysloglvl" -lt 4 ]; then
 		unset ddebug
 		ddebug()
 		{
@@ -154,7 +154,7 @@ dlog_init()
 		}
 	fi
 
-	if [ $kdump_stdloglvl -lt 3 ] && [ $kdump_kmsgloglvl -lt 3 ] && [ $kdump_sysloglvl -lt 3 ]; then
+	if [ "$kdump_stdloglvl" -lt 3 ] && [ "$kdump_kmsgloglvl" -lt 3 ] && [ "$kdump_sysloglvl" -lt 3 ]; then
 		unset dinfo
 		dinfo()
 		{
@@ -162,7 +162,7 @@ dlog_init()
 		}
 	fi
 
-	if [ $kdump_stdloglvl -lt 2 ] && [ $kdump_kmsgloglvl -lt 2 ] && [ $kdump_sysloglvl -lt 2 ]; then
+	if [ "$kdump_stdloglvl" -lt 2 ] && [ "$kdump_kmsgloglvl" -lt 2 ] && [ "$kdump_sysloglvl" -lt 2 ]; then
 		unset dwarn
 		dwarn()
 		{
@@ -175,7 +175,7 @@ dlog_init()
 		}
 	fi
 
-	if [ $kdump_stdloglvl -lt 1 ] && [ $kdump_kmsgloglvl -lt 1 ] && [ $kdump_sysloglvl -lt 1 ]; then
+	if [ "$kdump_stdloglvl" -lt 1 ] && [ "$kdump_kmsgloglvl" -lt 1 ] && [ "$kdump_sysloglvl" -lt 1 ]; then
 		unset derror
 		derror()
 		{
@@ -269,17 +269,17 @@ _dlvl2syslvl()
 #   - @c DEBUG to @c debug
 _do_dlog()
 {
-	[ "$1" -le $kdump_stdloglvl ] && printf -- 'kdump: %s\n' "$2" >&2
+	[ "$1" -le "$kdump_stdloglvl" ] && printf -- 'kdump: %s\n' "$2" >&2
 
-	if [ "$1" -le $kdump_sysloglvl ]; then
+	if [ "$1" -le "$kdump_sysloglvl" ]; then
 		if [ "$_dlogfd" ]; then
-			printf -- "<%s>%s\n" "$(($(_dlvl2syslvl "$1") & 7))" "$2" 1>&$_dlogfd
+			printf -- "<%s>%s\n" "$(($(_dlvl2syslvl "$1") & 7))" "$2" 1>&"$_dlogfd"
 		else
 			logger -t "kdump[$$]" -p "$(_lvl2syspri "$1")" -- "$2"
 		fi
 	fi
 
-	[ "$1" -le $kdump_kmsgloglvl ] &&
+	[ "$1" -le "$kdump_kmsgloglvl" ] &&
 		echo "<$(_dlvl2syslvl "$1")>kdump[$$] $2" > /dev/kmsg
 }
 

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -46,6 +46,7 @@ kdump_kmsgloglvl=""
 # be used in the first kernel because the dracut-lib.sh is invisible in
 # the first kernel.
 if [ -f /lib/dracut-lib.sh ]; then
+	# shellcheck source=/dev/null
 	. /lib/dracut-lib.sh
 fi
 

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -85,6 +85,7 @@ check_loglvl()
 # @brief Initializes Logger.
 # @retval 1 if something has gone wrong
 # @retval 0 on success.
+# shellcheck disable=SC2317 # skip for empty functions like dwarn
 #
 dlog_init()
 {

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -2,7 +2,7 @@
 
 systemctl is-active kdump
 if [ $? -ne 0 ]; then
-        exit 0
+	exit 0
 fi
 
 /usr/lib/kdump/kdump-restart.sh

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-systemctl is-active kdump
-if [ $? -ne 0 ]; then
+if ! systemctl is-active kdump; then
 	exit 0
 fi
 

--- a/kdump-restart.sh
+++ b/kdump-restart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$PATH:/usr/bin:/usr/sbin"
 
-exec >>/var/log/kdump-migration.log 2>&1
+exec >> /var/log/kdump-migration.log 2>&1
 
 echo "kdump: Partition Migration detected. Rebuilding initramfs image to reload."
 /usr/bin/kdumpctl rebuild

--- a/kdump-utils.spec
+++ b/kdump-utils.spec
@@ -21,6 +21,7 @@ Requires: dracut >= 058
 Requires: dracut-network >= 058
 Requires: dracut-squash >= 058
 Requires: ethtool
+Requires: gawk
 Requires: util-linux
 # Needed for UKI support
 Recommends: binutils

--- a/kdumpctl
+++ b/kdumpctl
@@ -59,8 +59,10 @@ _get_dracut_arg()
 	local shortopt longopt n tmp
 	local -a _opt _ret
 
-	shortopt=$1; shift
-	longopt=$1; shift
+	shortopt=$1
+	shift
+	longopt=$1
+	shift
 	n=0
 
 	if [[ -n $shortopt ]]; then
@@ -80,13 +82,14 @@ _get_dracut_arg()
 	eval set -- "$tmp"
 	while :; do
 		case $1 in
-			"$shortopt"|"$longopt")
-				_ret+=("$2"); shift
-				n=$((n+1))
-				;;
-			--|*)
-				break
-				;;
+		"$shortopt" | "$longopt")
+			_ret+=("$2")
+			shift
+			n=$((n + 1))
+			;;
+		-- | *)
+			break
+			;;
 		esac
 		shift
 	done
@@ -176,11 +179,11 @@ rebuild_kdump_initrd()
 
 check_and_generate_vconsole_conf()
 {
-	if [[ ! -e /etc/vconsole.conf  ]]; then
+	if [[ ! -e /etc/vconsole.conf ]]; then
 		dwarn "/etc/vconsole.conf does not exist, trying to set keymap to us to reduce the initramfs size."
 		if has_command localectl; then
 			if localectl list-keymaps | grep -q "^us$"; then
-				localectl set-keymap us 2>/dev/null
+				localectl set-keymap us 2> /dev/null
 			fi
 		fi
 	fi
@@ -645,11 +648,13 @@ is_system_modified()
 		$_func
 		ret=$?
 		# return immediately if an error occurred.
-		[[ $ret -eq "$CONF_ERROR" ]] && return "$ret"
-		[[ $ret -eq "$CONF_MODIFY" ]] && { conf_status="$CONF_MODIFY"; }
+		[[ $ret -eq $CONF_ERROR ]] && return "$ret"
+		[[ $ret -eq $CONF_MODIFY ]] && {
+			conf_status="$CONF_MODIFY"
+		}
 	done
 
-    return $conf_status
+	return $conf_status
 }
 
 # need_initrd_rebuild - check whether the initrd needs to be rebuild
@@ -749,9 +754,9 @@ check_ssh_config()
 {
 	local target
 
-	[[ "${OPT[_fstype]}" == ssh ]] || return 0
+	[[ ${OPT[_fstype]} == ssh ]] || return 0
 
-	target=$(ssh -G "${OPT[_target]}" | sed  -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
+	target=$(ssh -G "${OPT[_target]}" | sed -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
 
 	if [[ ${OPT[_target]} != *@* ]]; then
 		derror "Please verify that $KDUMP_CONFIG_FILE contains 'ssh <user>@<host>' and that it is properly formatted."
@@ -778,7 +783,7 @@ check_and_wait_network_ready()
 	local retval
 	local errmsg
 
-	[[ "${OPT[_fstype]}" == ssh ]] || return 0
+	[[ ${OPT[_fstype]} == ssh ]] || return 0
 
 	start_time=$(date +%s)
 	while true; do
@@ -824,7 +829,7 @@ propagate_ssh_key()
 
 	parse_config || return 1
 
-	if [[ ${OPT[_fstype]} != ssh ]] ; then
+	if [[ ${OPT[_fstype]} != ssh ]]; then
 		derror "No ssh destination defined in $KDUMP_CONFIG_FILE."
 		derror "Please verify that $KDUMP_CONFIG_FILE contains 'ssh <user>@<host>' and that it is properly formatted."
 		exit 1
@@ -983,10 +988,12 @@ check_dump_feasibility()
 
 fadump_bootargs_append()
 {
-	if [[ -f "$FADUMP_APPEND_ARGS_SYS_NODE" ]]; then
+	if [[ -f $FADUMP_APPEND_ARGS_SYS_NODE ]]; then
 		local output
 
-		if output=$( { echo "${FADUMP_COMMANDLINE_APPEND}" > "$FADUMP_APPEND_ARGS_SYS_NODE" ; } 2>&1); then
+		if output=$({
+			echo "${FADUMP_COMMANDLINE_APPEND}" > "$FADUMP_APPEND_ARGS_SYS_NODE"
+		} 2>&1); then
 			output=$(cat "$FADUMP_APPEND_ARGS_SYS_NODE")
 			dinfo "fadump: additional parameters for capture kernel: '$output'"
 		else
@@ -1071,15 +1078,15 @@ start()
 	setup_initrd || return
 	need_initrd_rebuild
 	case "$?" in
-		0)
-			# Nothing to do
-			;;
-		1)
-			rebuild_initrd || return
-			;;
-		*)
-			return
-			;;
+	0)
+		# Nothing to do
+		;;
+	1)
+		rebuild_initrd || return
+		;;
+	*)
+		return
+		;;
 	esac
 	start_dump || return
 
@@ -1248,7 +1255,7 @@ get_kernel_size()
 		try_decompress '\211\114\132' xy 'lzop -d' "$img" "$tmp" ||
 		try_decompress '\002!L\030' xxx 'lz4 -d' "$img" "$tmp" ||
 		try_decompress '(\265/\375' xxx unzstd "$img" "$tmp"; then
-			get_vmlinux_size "$tmp" && return 0
+		get_vmlinux_size "$tmp" && return 0
 	fi
 
 	# Fallback to use iomem
@@ -1270,15 +1277,15 @@ do_estimate()
 	setup_initrd
 	is_system_modified
 	case "$?" in
-		0)
-			# Nothing to do
-			;;
-		1)
-			rebuild_initrd || return
-			;;
-		*)
-			return
-			;;
+	0)
+		# Nothing to do
+		;;
+	1)
+		rebuild_initrd || return
+		;;
+	*)
+		return
+		;;
 	esac
 
 	kdump_mods="$(lsinitrd "$TARGET_INITRD" -f /usr/lib/dracut/hostonly-kernel-modules.txt | tr '\n' ' ')"
@@ -1452,18 +1459,18 @@ _update_kernel_cmdline()
 	_new="$4"
 
 	# _new = "" removes a _param, so _new = _old = "" is fine
-	[[ -n "$_new" ]] && [[ "$_old" == "$_new" ]] && return 1
+	[[ -n $_new ]] && [[ $_old == "$_new" ]] && return 1
 
 	if is_ostree; then
-		if [[ -z "$_new" ]]; then
+		if [[ -z $_new ]]; then
 			rpm-ostree kargs --delete="$_param=$_old"
-		elif [[ -n "$_old" ]]; then
+		elif [[ -n $_old ]]; then
 			rpm-ostree kargs --replace="$_param=$_new"
 		else
 			rpm-ostree kargs --append="$_param=$_new"
 		fi
 	elif has_command grubby; then
-		if [[ -n "$_new" ]]; then
+		if [[ -n $_new ]]; then
 			grubby --update-kernel "$_kernel" --args "$_param=$_new"
 		else
 			grubby --update-kernel "$_kernel" --remove-args "$_param"
@@ -1481,7 +1488,7 @@ _update_kernel_cmdline()
 
 _valid_grubby_kernel_path()
 {
-	[[ -n "$1" ]] && grubby --info="$1" > /dev/null 2>&1
+	[[ -n $1 ]] && grubby --info="$1" > /dev/null 2>&1
 }
 
 # return all the kernel paths given a grubby kernel-path
@@ -1510,36 +1517,36 @@ reset_crashkernel()
 
 	for _opt in "$@"; do
 		case "$_opt" in
-			--fadump=*)
-				if [[ $(uname -m) != ppc64le ]]; then
-					derror "Option --fadump only valid on PPC"
-					exit 1
-				fi
-				_opt_fadump=${_opt#*=}
-				if ! _dump_mode=$(get_dump_mode_by_fadump_val "$_opt_fadump"); then
-					derror "failed to determine dump mode"
-					exit
-				fi
-				;;
-			--kernel=*)
-				_val=${_opt#*=}
-				if ! _valid_grubby_kernel_path "$_val"; then
-					derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
-					exit
-				fi
-				_grubby_kernel_path=$_val
-				;;
-			--reboot)
-				# --reboot option was deprecated with
-				# kdump-utils v1.0.45. Keep the code for now to
-				# not break any user setup.
-				dwarn "Option --reboot is deprecated and will be removed in the future."
-				_reboot=yes
-				;;
-			*)
-				derror "$_opt not recognized"
+		--fadump=*)
+			if [[ $(uname -m) != ppc64le ]]; then
+				derror "Option --fadump only valid on PPC"
 				exit 1
-				;;
+			fi
+			_opt_fadump=${_opt#*=}
+			if ! _dump_mode=$(get_dump_mode_by_fadump_val "$_opt_fadump"); then
+				derror "failed to determine dump mode"
+				exit
+			fi
+			;;
+		--kernel=*)
+			_val=${_opt#*=}
+			if ! _valid_grubby_kernel_path "$_val"; then
+				derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
+				exit
+			fi
+			_grubby_kernel_path=$_val
+			;;
+		--reboot)
+			# --reboot option was deprecated with
+			# kdump-utils v1.0.45. Keep the code for now to
+			# not break any user setup.
+			dwarn "Option --reboot is deprecated and will be removed in the future."
+			_reboot=yes
+			;;
+		*)
+			derror "$_opt not recognized"
+			exit 1
+			;;
 		esac
 	done
 
@@ -1574,13 +1581,13 @@ reset_crashkernel()
 	for _kernel in $_kernels; do
 		_has_changed=""
 		if [[ $(uname -m) == ppc64le ]]; then
-			if [[ -n "$_opt_fadump" ]]; then
+			if [[ -n $_opt_fadump ]]; then
 				_new_ck=$(kdump_get_arch_recommend_crashkernel "$_dump_mode")
 				_old_fadump=$(get_grub_kernel_boot_parameter "$_kernel" fadump)
 				_new_fadump="$_opt_fadump"
-				[[ "$_new_fadump" == off ]] && _new_fadump=""
+				[[ $_new_fadump == off ]] && _new_fadump=""
 				if _update_kernel_cmdline "$_kernel" fadump "$_old_fadump" "$_new_fadump"; then
-					if [[ -n "$_new_fadump" ]]; then
+					if [[ -n $_new_fadump ]]; then
 						_has_changed="Updated fadump=$_new_fadump"
 					else
 						_has_changed="Removed fadump"
@@ -1598,7 +1605,7 @@ reset_crashkernel()
 		if _update_kernel_cmdline "$_kernel" crashkernel "$_old_ck" "$_new_ck"; then
 			_has_changed="Updated crashkernel=$_new_ck"
 		fi
-		if [[ -n "$_has_changed" ]]; then
+		if [[ -n $_has_changed ]]; then
 			_needs_reboot=1
 			dwarn "$_has_changed for kernel=$_kernel. Please reboot the system for the change to take effect."
 		fi
@@ -1636,7 +1643,6 @@ _update_crashkernel()
 		dinfo "$_msg"
 	fi
 }
-
 
 # shellcheck disable=SC2154 # false positive when dereferencing an array
 reset_crashkernel_after_update()
@@ -1695,7 +1701,8 @@ reset_crashkernel_for_installed_kernel()
 	_update_crashkernel "$_installed_kernel"
 }
 
-_should_reset_crashkernel() {
+_should_reset_crashkernel()
+{
 	[[ $(kdump_get_conf_val auto_reset_crashkernel) != no ]] && systemctl is-enabled kdump &> /dev/null
 }
 
@@ -1705,7 +1712,7 @@ set_kdump_test_id()
 
 	KDUMP_COMMANDLINE_APPEND+=" $_id "
 
-	if ! reload >& /dev/null; then
+	if ! reload >&/dev/null; then
 		derror "Set kdump test id fail."
 		exit 1
 	fi
@@ -1719,23 +1726,24 @@ set_vmcore_creation_status()
 	local _kdump_test_id
 	_dir=$(dirname "$VMCORE_CREATION_STATUS")
 
-	[[ -d "$_dir" ]] || mkdir -p "$_dir"
-	[[ -w "$_dir" ]] || chmod +w "$_dir"
+	[[ -d $_dir ]] || mkdir -p "$_dir"
+	[[ -w $_dir ]] || chmod +w "$_dir"
 
 	case "$_status" in
-		pending)
-			_kdump_test_id="kdump_test_id=$(date +%s-%N)"
-			set_kdump_test_id "$_kdump_test_id"
-			echo  "$_status $_kdump_test_id" > "$VMCORE_CREATION_STATUS"
-			;;
-		success | fail | manual)
-			sed -E -i "s/^\w+/$_status/" "$VMCORE_CREATION_STATUS"
-			;;
-		clear)
-			rm -f "$VMCORE_CREATION_STATUS"
-			;;
-		*)
-			return
+	pending)
+		_kdump_test_id="kdump_test_id=$(date +%s-%N)"
+		set_kdump_test_id "$_kdump_test_id"
+		echo "$_status $_kdump_test_id" > "$VMCORE_CREATION_STATUS"
+		;;
+	success | fail | manual)
+		sed -E -i "s/^\w+/$_status/" "$VMCORE_CREATION_STATUS"
+		;;
+	clear)
+		rm -f "$VMCORE_CREATION_STATUS"
+		;;
+	*)
+		return
+		;;
 	esac
 	sync -f "$_dir"
 }
@@ -1743,7 +1751,7 @@ set_vmcore_creation_status()
 fetch_status()
 {
 	local _test_id="$1" _mnt
-	local  _status
+	local _status
 
 	is_raw_dump_target && return 2
 
@@ -1751,10 +1759,12 @@ fetch_status()
 
 	if is_nfs_dump_target || is_local_target; then
 		_mnt=$(get_mntpoint_from_target "${OPT[_target]}")
-		if [[ -z "$_mnt" ]] || ! is_mounted "$_mnt"; then
+		if [[ -z $_mnt ]] || ! is_mounted "$_mnt"; then
 			mkdir -p "$TMPMNT"
-			mount "${OPT[_target]}" "$TMPMNT" -t "${OPT[_fstype]}" -o defaults || \
-				{ dwarn "Failed to mount ${OPT[_target]}" && return 2; }
+			mount "${OPT[_target]}" "$TMPMNT" -t "${OPT[_fstype]}" -o defaults ||
+				{
+					dwarn "Failed to mount ${OPT[_target]}" && return 2
+				}
 			_mnt="$TMPMNT"
 		fi
 		_status="$_mnt/$_status"
@@ -1771,21 +1781,22 @@ fetch_status()
 			"$_scp_address:$_status" \
 			"$KDUMP_TMPDIR"
 		case "$?" in
-			0)
-				# success
-				;;
-			1)
-				# file not found
-				return 1
-				;;
-			255)
-				# no connection to host
-				return 2
+		0)
+			# success
+			;;
+		1)
+			# file not found
+			return 1
+			;;
+		255)
+			# no connection to host
+			return 2
+			;;
 		esac
 		_status="$KDUMP_TMPDIR/vmcore-creation.status"
 	fi
 
-	[[ -f "$_status" ]] || return 1
+	[[ -f $_status ]] || return 1
 	grep -q "success" "$_status" && return 0 || return 1
 }
 
@@ -1795,21 +1806,23 @@ check_vmcore_creation_status()
 
 	[[ ${VMCORE_CREATION_NOTIFICATION,,} == "yes" ]] || return
 
-	[[ "$DEFAULT_DUMP_MODE" == "kdump" ]] || return
+	[[ $DEFAULT_DUMP_MODE == "kdump" ]] || return
 
-	if [[ ! -s "$VMCORE_CREATION_STATUS" ]]; then
+	if [[ ! -s $VMCORE_CREATION_STATUS ]]; then
 		dwarn "Notice: No vmcore creation test performed!"
 		return
 	fi
 
-	[[ "${#OPT[@]}" -eq 0 ]] && { parse_config || return; }
+	[[ ${#OPT[@]} -eq 0 ]] && {
+		parse_config || return
+	}
 
 	read -r _status _test_id < "$VMCORE_CREATION_STATUS"
 	_test_id=${_test_id#*=}
 	_timestamp=${_test_id%-*}
 	_status_date=$(date -d "@$_timestamp")
 
-	if [[ "$_status" == "pending" ]]; then
+	if [[ $_status == "pending" ]]; then
 		fetch_status "$_test_id"
 		case "$?" in
 		0)
@@ -1826,18 +1839,18 @@ check_vmcore_creation_status()
 	fi
 
 	case "$_status" in
-		success)
-			dinfo "Notice: Last successful vmcore creation on $_status_date"
-			;;
-		fail)
-			dwarn "Notice: Last NOT successful vmcore creation on $_status_date"
-			;;
-		manual)
-			dwarn "Notice: Require manual check for kdump test of $_status_date"
-			;;
-		*)
-			derror "Unknown test status: $_status"
-			;;
+	success)
+		dinfo "Notice: Last successful vmcore creation on $_status_date"
+		;;
+	fail)
+		dwarn "Notice: Last NOT successful vmcore creation on $_status_date"
+		;;
+	manual)
+		dwarn "Notice: Require manual check for kdump test of $_status_date"
+		;;
+	*)
+		derror "Unknown test status: $_status"
+		;;
 	esac
 }
 
@@ -1848,18 +1861,18 @@ kdump_test()
 		exit 1
 	fi
 
-	if [[ ! "$DEFAULT_DUMP_MODE" == "kdump" ]]; then
+	if [[ $DEFAULT_DUMP_MODE != "kdump" ]]; then
 		derror "Only kdump is supported for test."
 		exit 1
 	fi
 
-	if [[ ! "$1" == "--force" ]]; then
+	if [[ $1 != "--force" ]]; then
 		read -r -p "DANGER!!! Will perform a kdump test by crashing the system, proceed? (y/N): " input
 		case $input in
-		[Yy] )
+		[Yy])
 			dinfo "Start kdump test..."
 			;;
-		* )
+		*)
 			dinfo "Operation cancelled."
 			exit 0
 			;;

--- a/kdumpctl
+++ b/kdumpctl
@@ -1306,7 +1306,7 @@ do_estimate()
 	reserved_size=$(get_reserved_mem_size)
 	# A pre-estimated value for userspace usage and kernel
 	# runtime allocation, 64M should good for most cases
-	runtime_size=$((64 * size_mb))
+	runtime_size=$((16 * size_mb))
 	# Kernel image size
 	kernel_size=$(get_kernel_size "$KDUMP_KERNEL")
 	# Kdump initramfs size
@@ -1347,7 +1347,7 @@ do_estimate()
 		echo -e "Encrypted kdump target requires extra memory, assuming using the keyslot with maximum memory requirement\n"
 	fi
 
-	estimated_size=$((kernel_size + mod_size + initrd_size + runtime_size + crypt_size))
+	estimated_size=$((kernel_size + mod_size + initrd_size * 3 + runtime_size + crypt_size))
 	if [[ $baseline_size -gt $estimated_size ]]; then
 		recommended_size=$baseline_size
 	else

--- a/kdumpctl
+++ b/kdumpctl
@@ -1714,7 +1714,7 @@ set_kdump_test_id()
 
 	KDUMP_COMMANDLINE_APPEND+=" $_id "
 
-	if ! reload >&/dev/null; then
+	if ! reload > /dev/null; then
 		derror "Set kdump test id fail."
 		exit 1
 	fi
@@ -1931,6 +1931,7 @@ main()
 			derror "Starting kdump: [FAILED]"
 			exit 1
 		fi
+		check_vmcore_creation_status
 		;;
 	rebuild)
 		rebuild

--- a/kdumpctl
+++ b/kdumpctl
@@ -992,6 +992,7 @@ fadump_bootargs_append()
 	if [[ -f $FADUMP_APPEND_ARGS_SYS_NODE ]]; then
 		local output
 
+		# shellcheck disable=SC2153
 		if output=$({
 			echo "${FADUMP_COMMANDLINE_APPEND}" > "$FADUMP_APPEND_ARGS_SYS_NODE"
 		} 2>&1); then

--- a/kdumpctl
+++ b/kdumpctl
@@ -1297,7 +1297,7 @@ do_estimate()
 	elif [[ ${baseline: -1} == "G" ]]; then
 		baseline=$((${baseline%G} * 1024))
 	elif [[ ${baseline: -1} == "T" ]]; then
-		baseline=$((${baseline%Y} * 1048576))
+		baseline=$((${baseline%T} * 1048576))
 	fi
 
 	# The default pre-reserved crashkernel value

--- a/kdumpctl
+++ b/kdumpctl
@@ -22,6 +22,7 @@ KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug"
 declare -A OPT
 
 if [[ -f /etc/sysconfig/kdump ]]; then
+	# shellcheck source=/dev/null
 	. /etc/sysconfig/kdump
 fi
 

--- a/mkdumprd
+++ b/mkdumprd
@@ -433,7 +433,7 @@ if ! is_fadump_capable; then
 	# If /boot is not on a separate partition, the fips dracut module will
 	# link /sysroot/boot to /boot. So we need to mount the root partition
 	# to /sysroot beforehand.
-	if [[ $(cat /proc/sys/crypto/fips_enabled 2> /dev/null) == 1  ]]; then
+	if [[ $(cat /proc/sys/crypto/fips_enabled 2> /dev/null) == 1 ]]; then
 		_boot_source=$(findmnt -n -o SOURCE --target /boot)
 		if mountpoint -q /boot; then
 			dracut_args+=(--add-device "$_boot_source")
@@ -445,7 +445,7 @@ fi
 
 # Use kdump managed dracut profile.
 [[ $kdump_dracut_confdir ]] || kdump_dracut_confdir=/lib/kdump/dracut.conf.d
-if [[ "$(dracut --help)" == *--add-confdir* ]] && [[ -d "$kdump_dracut_confdir" ]]; then
+if [[ "$(dracut --help)" == *--add-confdir* ]] && [[ -d $kdump_dracut_confdir ]]; then
 	dracut_args+=("--add-confdir" "$kdump_dracut_confdir")
 else
 	dracut_args+=(--add kdumpbase)

--- a/mkdumprd
+++ b/mkdumprd
@@ -9,6 +9,7 @@
 [[ -n $debug ]] && set -x
 
 if [[ -f /etc/sysconfig/kdump ]]; then
+	# shellcheck source=/dev/null
 	. /etc/sysconfig/kdump
 fi
 

--- a/mkdumprd
+++ b/mkdumprd
@@ -43,7 +43,7 @@ MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."
 MKDUMPRD_TMPMNT="$MKDUMPRD_TMPDIR/target"
 
-# shellcheck disable=SC2154
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     is_mounted $MKDUMPRD_TMPMNT && umount -f $MKDUMPRD_TMPMNT;

--- a/mkfadumprd
+++ b/mkfadumprd
@@ -3,6 +3,7 @@
 # the default initramfs using zz-fadumpinit dracut module.
 
 if [[ -f /etc/sysconfig/kdump ]]; then
+	# shellcheck source=/dev/null
 	. /etc/sysconfig/kdump
 fi
 

--- a/mkfadumprd
+++ b/mkfadumprd
@@ -22,7 +22,7 @@ fi
 
 MKFADUMPRD_TMPDIR="$(mktemp -d -t mkfadumprd.XXXXXX)"
 [ -d "$MKFADUMPRD_TMPDIR" ] || perror_exit "mkfadumprd: mktemp -d -t mkfadumprd.XXXXXX failed."
-# shellcheck disable=SC2154
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     [[ -d $MKFADUMPRD_TMPDIR ]] && rm --one-file-system -rf -- "$MKFADUMPRD_TMPDIR";

--- a/spec/kdumpctl_general_spec.sh
+++ b/spec/kdumpctl_general_spec.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2286
+
 Describe 'kdumpctl'
 	Include ./kdumpctl
 

--- a/spec/kdumpctl_general_spec.sh
+++ b/spec/kdumpctl_general_spec.sh
@@ -128,7 +128,7 @@ Describe 'kdumpctl'
 	Describe "is_dracut_mod_omitted()"
 		KDUMP_CONFIG_FILE=$(mktemp -t kdump_conf.XXXXXXXXXX)
 		cleanup() {
-			rm -f "$kdump_conf"
+			rm -f "$KDUMP_CONFIG_FILE"
 		}
 		AfterAll 'cleanup'
 

--- a/spec/kdumpctl_general_spec.sh
+++ b/spec/kdumpctl_general_spec.sh
@@ -120,7 +120,7 @@ Describe 'kdumpctl'
 		End
 		It "should parse the dracut_args correctly"
 			When call _get_dracut_arg "$1" "$2" "$dracut_args"
-			The status should equal $3
+			The status should equal "$3"
 			The output should equal "$4"
 		End
 	End
@@ -150,10 +150,10 @@ Describe 'kdumpctl'
 			%data failure foo "-a x -i y"
 		End
 		It "shall return $1 for module $2 and dracut_args '$3'"
-			echo "dracut_args $3" > $KDUMP_CONFIG_FILE
+			echo "dracut_args $3" > "$KDUMP_CONFIG_FILE"
 			parse_config
-			When call is_dracut_mod_omitted $2
-			The status should be $1
+			When call is_dracut_mod_omitted "$2"
+			The status should be "$1"
 		End
 	End
 

--- a/spec/kdumpctl_manage_crashkernel_spec.sh
+++ b/spec/kdumpctl_manage_crashkernel_spec.sh
@@ -12,8 +12,6 @@ Describe 'Management of the kernel crashkernel parameter.'
 	uname() {
 		if [[ $1 == '-m' ]]; then
 			echo -n x86_64
-		elif [[ $1 == '-r' ]]; then
-			echo -n $current_kernel
 		fi
 	}
 

--- a/spec/kdumpctl_manage_crashkernel_spec.sh
+++ b/spec/kdumpctl_manage_crashkernel_spec.sh
@@ -30,8 +30,8 @@ Describe 'Management of the kernel crashkernel parameter.'
 		cp spec/support/grub_env "$KDUMP_SPEC_TEST_RUN_DIR"/env_temp
 		touch "$GRUB_CFG"
 
-		grubby --args crashkernel=$old_ck --update-kernel=$kernel1
-		grubby --args crashkernel=$new_ck --update-kernel=$kernel2
+		grubby --args crashkernel="$old_ck" --update-kernel="$kernel1"
+		grubby --args crashkernel="$new_ck" --update-kernel="$kernel2"
 		grubby --remove-args fadump --update-kernel=ALL
 
 	}
@@ -75,12 +75,12 @@ Describe 'Management of the kernel crashkernel parameter.'
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$new_ck"
 			End
 
 			Specify 'kernel2 should also have crashkernel updated'
-				When call grubby --info $kernel2
+				When call grubby --info "$kernel2"
 				The line 3 of output should include crashkernel="$new_ck"
 			End
 
@@ -93,20 +93,20 @@ Describe 'Management of the kernel crashkernel parameter.'
 			setup
 			new_kernel_ver=new_kernel
 			new_kernel=/boot/vmlinuz-$new_kernel_ver
-			grubby --add-kernel=$new_kernel --initrd=/boot/initramfs-$new_kernel_ver.img --title=$new_kernel_ver
+			grubby --add-kernel="$new_kernel" --initrd=/boot/initramfs-"$new_kernel_ver".img --title="$new_kernel_ver"
 
 			Specify 'reset_crashkernel_for_installed_kernel should report the new kernel has its crashkernel updated'
-				When call reset_crashkernel_for_installed_kernel $new_kernel_ver
+				When call reset_crashkernel_for_installed_kernel "$new_kernel_ver"
 				The output should include "crashkernel=$new_ck"
 			End
 
 			Specify 'the new kernel should have crashkernel updated'
-				When call grubby --info $new_kernel
+				When call grubby --info "$new_kernel"
 				The output should include crashkernel="$new_ck"
 			End
 
 			Specify 'kernel1 keeps its crashkernel value'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The output should include crashkernel="$old_ck"
 			End
 

--- a/spec/kdumpctl_reset_crashkernel_spec.sh
+++ b/spec/kdumpctl_reset_crashkernel_spec.sh
@@ -45,31 +45,31 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			if [[ $1 == '-m' ]]; then
 				echo -n x86_64
 			elif [[ $1 == '-r' ]]; then
-				echo -n $current_kernel
+				echo -n "$current_kernel"
 			fi
 		}
 		kdump_crashkernel=$(get_default_crashkernel kdump)
 		Context "when --kernel not specified"
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			Specify 'kdumpctl should warn the user that crashkernel has been udpated'
 				When call reset_crashkernel
 				The error should include "Updated crashkernel=$kdump_crashkernel"
 			End
 
 			Specify 'Current running kernel should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$kdump_crashkernel"
-				The line 3 of output should not include crashkernel=$ck
+				The line 3 of output should not include crashkernel="$ck"
 			End
 
 			Specify 'Other kernel still use the old crashkernel value'
-				When call grubby --info $kernel2
-				The line 3 of output should include crashkernel=$ck
+				When call grubby --info "$kernel2"
+				The line 3 of output should include crashkernel="$ck"
 			End
 		End
 
 		Context "--kernel=ALL"
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			Specify 'kdumpctl should warn the user that crashkernel has been udpated'
 				When call reset_crashkernel --kernel=ALL
 				The error should include "Updated crashkernel=$kdump_crashkernel for kernel=$kernel1"
@@ -77,31 +77,31 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$kdump_crashkernel"
 			End
 
 			Specify 'kernel2 should have crashkernel updated'
-				When call grubby --info $kernel2
+				When call grubby --info "$kernel2"
 				The line 3 of output should include crashkernel="$kdump_crashkernel"
 			End
 		End
 
 		Context "--kernel=/boot/one-kernel to update one specified kernel"
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			Specify 'kdumpctl should warn the user that crashkernel has been updated'
-				When call reset_crashkernel --kernel=$kernel1
+				When call reset_crashkernel --kernel="$kernel1"
 				The error should include "Updated crashkernel=$kdump_crashkernel for kernel=$kernel1"
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$kdump_crashkernel"
 			End
 
 			Specify 'kernel2 should have the old crashkernel'
-				When call grubby --info $kernel2
-				The line 3 of output should include crashkernel=$ck
+				When call grubby --info "$kernel2"
+				The line 3 of output should include crashkernel="$ck"
 			End
 
 		End
@@ -113,14 +113,14 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			if [[ $1 == '-m' ]]; then
 				echo -n ppc64le
 			elif [[ $1 == '-r' ]]; then
-				echo -n $current_kernel
+				echo -n "$current_kernel"
 			fi
 		}
 
 		kdump_crashkernel=$(get_default_crashkernel kdump)
 		fadump_crashkernel=$(get_default_crashkernel fadump)
 		Context "when no --kernel specified"
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			grubby --remove-args=fadump --update-kernel ALL
 			Specify 'kdumpctl should warn the user that crashkernel has been udpated'
 				When call reset_crashkernel
@@ -128,18 +128,18 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			End
 
 			Specify 'Current running kernel should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$kdump_crashkernel"
 			End
 
 			Specify 'Other kernel still use the old crashkernel value'
-				When call grubby --info $kernel2
-				The line 3 of output should include crashkernel=$ck
+				When call grubby --info "$kernel2"
+				The line 3 of output should include crashkernel="$ck"
 			End
 		End
 
 		Context "--kernel=ALL --fadump=on"
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			Specify 'kdumpctl should warn the user that crashkernel has been udpated'
 				When call reset_crashkernel --kernel=ALL --fadump=on
 				The error should include "Updated crashkernel=$fadump_crashkernel for kernel=$kernel1"
@@ -147,56 +147,56 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$fadump_crashkernel"
 			End
 
 			Specify 'kernel2 should have crashkernel updated'
-				When call get_grub_kernel_boot_parameter $kernel2 crashkernel
+				When call get_grub_kernel_boot_parameter "$kernel2" crashkernel
 				The output should equal "$fadump_crashkernel"
 			End
 		End
 
 		Context "--kernel=/boot/one-kernel to update one specified kernel"
-			grubby --args crashkernel=$ck --update-kernel ALL
-			grubby --args fadump=on --update-kernel $kernel1
+			grubby --args crashkernel="$ck" --update-kernel ALL
+			grubby --args fadump=on --update-kernel "$kernel1"
 			Specify 'kdumpctl should warn the user that crashkernel has been updated'
-				When call reset_crashkernel --kernel=$kernel1
+				When call reset_crashkernel --kernel="$kernel1"
 				The error should include "Updated crashkernel=$fadump_crashkernel for kernel=$kernel1"
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call grubby --info $kernel1
+				When call grubby --info "$kernel1"
 				The line 3 of output should include crashkernel="$fadump_crashkernel"
 			End
 
 			Specify 'kernel2 should have the old crashkernel'
-				When call get_grub_kernel_boot_parameter $kernel2 crashkernel
-				The output should equal $ck
+				When call get_grub_kernel_boot_parameter "$kernel2" crashkernel
+				The output should equal "$ck"
 			End
 		End
 
 		Context "Update all kernels but without --fadump specified"
-			grubby --args crashkernel=$ck --update-kernel ALL
-			grubby --args fadump=on --update-kernel $kernel1
+			grubby --args crashkernel="$ck" --update-kernel ALL
+			grubby --args fadump=on --update-kernel "$kernel1"
 			Specify 'kdumpctl should warn the user that crashkernel has been updated'
-				When call reset_crashkernel --kernel=$kernel1
+				When call reset_crashkernel --kernel="$kernel1"
 				The error should include "Updated crashkernel=$fadump_crashkernel for kernel=$kernel1"
 			End
 
 			Specify 'kernel1 should have crashkernel updated'
-				When call get_grub_kernel_boot_parameter $kernel1 crashkernel
+				When call get_grub_kernel_boot_parameter "$kernel1" crashkernel
 				The output should equal "$fadump_crashkernel"
 			End
 
 			Specify 'kernel2 should have the old crashkernel'
-				When call get_grub_kernel_boot_parameter $kernel2 crashkernel
-				The output should equal $ck
+				When call get_grub_kernel_boot_parameter "$kernel2" crashkernel
+				The output should equal "$ck"
 			End
 		End
 
 		Context 'Switch between fadump=on and fadump=nocma'
-			grubby --args crashkernel=$ck --update-kernel ALL
+			grubby --args crashkernel="$ck" --update-kernel ALL
 			grubby --args fadump=on --update-kernel ALL
 			Specify 'fadump=on to fadump=nocma'
 				When call reset_crashkernel --kernel=ALL --fadump=nocma
@@ -205,7 +205,7 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			End
 
 			Specify 'kernel1 should have fadump=nocma in cmdline'
-				When call get_grub_kernel_boot_parameter $kernel1 fadump
+				When call get_grub_kernel_boot_parameter "$kernel1" fadump
 				The output should equal nocma
 			End
 
@@ -215,7 +215,7 @@ Describe 'kdumpctl reset-crashkernel [--kernel] [--fadump]'
 			End
 
 			Specify 'kernel2 should have fadump=on in cmdline'
-				When call get_grub_kernel_boot_parameter $kernel1 fadump
+				When call get_grub_kernel_boot_parameter "$kernel1" fadump
 				The output should equal on
 			End
 

--- a/supported-kdump-targets.txt
+++ b/supported-kdump-targets.txt
@@ -47,6 +47,8 @@ storage:
         software FCoE (bnx2fc) (Extra configuration required,
             please read "Note on FCoE" section below)
         NVMe-FC (qla2xxx, lpfc)
+        NVMe/TCP configured by NVMe Boot Firmware Table (users may need to
+            increase the crashkernel value)
 
 network:
         Hardware using kernel modules: (igb, ixgbe, ice, i40e, e1000e, igc,

--- a/tests/setup/ovs_network/test.sh
+++ b/tests/setup/ovs_network/test.sh
@@ -3,15 +3,15 @@
 ovs_configure_script=/usr/local/bin/configure-ovs.sh
 
 extract_configure-ovs-script() {
-   local _script_url
+    local _script_url
 
-   _script_url=https://github.com/openshift/machine-config-operator/raw/refs/heads/master/templates/common/_base/files/configure-ovs-network.yaml
+    _script_url=https://github.com/openshift/machine-config-operator/raw/refs/heads/master/templates/common/_base/files/configure-ovs-network.yaml
 
-   if curl -sL $_script_url | grep -A2000 '#!/bin/bash' > "$ovs_configure_script";  then
-       chmod +x "$ovs_configure_script"
-   else
-       return 1
-   fi
+    if curl -sL $_script_url | grep -A2000 '#!/bin/bash' > "$ovs_configure_script"; then
+        chmod +x "$ovs_configure_script"
+    else
+        return 1
+    fi
 }
 
 create_bond_network() {
@@ -22,7 +22,6 @@ create_bond_network() {
     nmcli con add type ethernet ifname "$_ifname" master bond0
     nmcli con up "bond-slave-$_ifname"
 }
-
 
 systemctl enable --now openvswitch
 # restart NM so the ovs plugin can be activated

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -29,4 +29,4 @@ if [[ ! -f $rpm_path ]]; then
 	echo "Failed to find built kdump-utils rpm ($rpm_path doesn't eixst)"
 fi
 
-cd tests && tmt --context distro="fedora-${fedora_version}" run --environment CUSTOM_MIRROR=$mirror --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"
+cd tests && tmt --context distro="fedora-${fedora_version}" run --environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i fedora:"$fedora_version"


### PR DESCRIPTION
A memory peak in kdump occurs when the initramfs is being decompressed. At this
moment, both the compressed and decompressed initramfs coexist in memory. After
this, the compressed initramfs is released.

This patch enhances the `do_estimate` function in `kdumpctl` by incorporating
the size of the unpacked initramfs contents into the crashkernel memory
estimation. The following changes have been made:

- Added logic to extract and measure the size of the unpacked initramfs,
  including any squashfs/erofs images.
- Adjusted the default runtime reservation from 64M to 32M to better reflect
  typical use cases.
- Updated output to display the unpacked initramfs size.

These improvements help ensure a more accurate memory reservation for kdump
environments.

Signed-off-by: Lichen Liu <lichliu@redhat.com>

## Summary by Sourcery

Improve memory estimation for kdump by accurately calculating initramfs memory requirements

Bug Fixes:
- Adjust crashkernel memory reservation to more accurately reflect actual memory usage during kdump initialization

Enhancements:
- Enhance memory estimation logic in kdumpctl to consider unpacked initramfs size and its contents

Chores:
- Reduce default runtime memory reservation from 64M to 32M to better match typical use cases