### PR TITLE
99-kdump.conf: Omit clevis related dracut modules

### DIFF
--- a/99-kdump.conf
+++ b/99-kdump.conf
@@ -1,4 +1,5 @@
 dracutmodules=''
 add_dracutmodules=' kdumpbase '
 omit_dracutmodules=' hwdb rdma plymouth resume ifcfg earlykdump '
+omit_dracutmodules+=' clevis clevis-pin-null clevis-pin-tang clevis-pin-sss clevis-pin-tpm2 '
 omit_drivers+=' nouveau amdgpu '


### PR DESCRIPTION
The clevis related dracut modules are unconditionly included into the kdump initramfs after installing clevis-dracut package.

Normally, we don't use clevis in the kdump process, but it will increase the size of kdump initramfs by about 11M, which is a relatively large overhead for kdump. Omit them by default can reduce the memory required by kdump and avoid the OOM issue.

If the user really needs to use it, it can also be added to kdump initramfs by using dracut_args --force-add in /etc/kdump.conf.

Resolves: https://issues.redhat.com/browse/RHEL-19064
Related: https://issues.redhat.com/browse/RHEL-77112