### PR TITLE
kdumpctl: check and generate /etc/vconsole.conf

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -174,6 +174,18 @@ rebuild_kdump_initrd()
 	return 0
 }
 
+check_and_generate_vconsole_conf()
+{
+	if [[ ! -e /etc/vconsole.conf  ]]; then
+		dwarn "/etc/vconsole.conf does not exist, trying to set keymap to us to reduce the initramfs size."
+		if has_command localectl; then
+			if localectl list-keymaps | grep -q "^us$"; then
+				localectl set-keymap us 2>/dev/null
+			fi
+		fi
+	fi
+}
+
 rebuild_initrd()
 {
 	local _ret
@@ -184,6 +196,8 @@ rebuild_initrd()
 		derror "$(dirname "$TARGET_INITRD") does not have write permission. Cannot rebuild $TARGET_INITRD"
 		return 1
 	fi
+
+	check_and_generate_vconsole_conf
 
 	if [[ $DEFAULT_DUMP_MODE == "fadump" ]]; then
 		rebuild_fadump_initrd


### PR DESCRIPTION
For VMs created from KVM Guest images, /etc/vconsole.conf is missing
so that dracut module 10i18n will install all kbd files.

```
  # du -sh initramfs/squash/usr/lib/kbd/*
  438K    initramfs/squash/usr/lib/kbd/consolefonts
  340K    initramfs/squash/usr/lib/kbd/consoletrans
  2.1M    initramfs/squash/usr/lib/kbd/keymaps
  232K    initramfs/squash/usr/lib/kbd/unimaps
```

From man 5 vconsole.conf, KEYMAP= defaults to "us" if not set. We can
safely generate a /etc/vconsole.conf with KEYMAP=us by localectl to
reduce the initramfs size.

```
  # du -sh initramfs/squash/usr/lib/kbd/*
  11K     initramfs/squash/usr/lib/kbd/consolefonts
  121K    initramfs/squash/usr/lib/kbd/keymaps
```

Signed-off-by: Lichen Liu <lichliu@redhat.com>

## Summary by Sourcery

Modify kdumpctl to check and generate /etc/vconsole.conf for VMs with missing console configuration

Bug Fixes:
- Ensure proper keyboard configuration for VMs created from KVM Guest images

Enhancements:
- Automatically generate /etc/vconsole.conf with default US keymap to reduce initramfs size