### PR TITLE
RFC: Send standard error of capture service to TTY

### DIFF
--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -182,7 +182,7 @@ dump_fs() {
     KDUMP_LOG_DEST=$_dump_fs_path/
     KDUMP_LOG_OP="mv '$KDUMP_LOG_FILE' '$KDUMP_LOG_DEST/'"
 
-    $CORE_COLLECTOR /proc/vmcore "$_dump_fs_path/vmcore-incomplete"
+    $CORE_COLLECTOR /proc/vmcore "$_dump_fs_path/vmcore-incomplete" > /dev/console 2>&1
     _dump_exitcode=$?
     if [ $_dump_exitcode -eq 0 ]; then
         sync -f "$_dump_fs_path/vmcore-incomplete"


### PR DESCRIPTION
On PowerPC, makedumpfile fails to print the ETA during dump collection if the StandardError of the kdump capture service is configured to journal+console. Changing it to tty fixes the issue.

Changing StandardError to tty may not be the right approach, but this patch is being sent to discuss possible solutions to the problem, since the same service is used on other architectures as well.

In the kdump kernel, the system does have /dev/console, but for some reason, makedumpfile running via the capture service is not able to print the ETA during dump collection.

Running the following command:
  ```$ echo "hello" > /dev/console```

prints hello on the console in the kdump emergency shell.

## Summary by Sourcery

Bug Fixes:
- Configure kdump-capture.service to send stderr to tty to restore makedumpfile’s ETA output during dump collection on PowerPC