### PR TITLE
kdump.conf add dracut_kdump_service_timeout

### DIFF
--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1051,10 +1051,11 @@ kdump_install_random_seed() {
 kdump_install_systemd_conf() {
     # Kdump turns out to require longer default systemd mount timeout
     # than 1st kernel(45s by default), we use default 300s for kdump.
+    kdump_timeout=$(get_kdump_service_timeout)
     mkdir -p "${initdir}/etc/systemd/system.conf.d"
     cat > "${initdir}/etc/systemd/system.conf.d/99-kdump.conf" << EOF
 [Manager]
-DefaultTimeoutStartSec=300s
+DefaultTimeoutStartSec=${kdump_timeout}s
 EOF
 
     # Forward logs to console directly, and don't read Kmsg, this avoids

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -5,6 +5,7 @@
 
 DEFAULT_PATH="/var/crash/"
 DEFAULT_SSHKEY="/root/.ssh/kdump_id_rsa"
+DEFAULT_KDUMP_TIMEOUT=300
 KDUMP_CONFIG_FILE="/etc/kdump.conf"
 FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -347,6 +347,14 @@ get_reserved_mem_size()
 	echo "$reserved_mem_size"
 }
 
+get_kdump_service_timeout(){
+	timeout=$(kdump_get_conf_val "dracut_kdump_service_timeout")
+	if [ -z "$timeout" ];then
+		timeout=$DEFAULT_KDUMP_TIMEOUT
+	fi
+	echo $timeout
+}
+
 check_crash_mem_reserved()
 {
 	local mem_reserved

--- a/kdump.conf.5
+++ b/kdump.conf.5
@@ -284,6 +284,12 @@ Now dracut network module takes care of this issue automatically.
 Similar to link_delay, dracut ensures disks are ready before kdump uses them.
 .RE
 
+.B dracut_kdump_service_timeout <seconds>
+.RS
+dracut kdump service start timeout.
+The default value is 300 seconds.
+.RE
+
 .B debug_mem_level <0-3>
 .RS
 Turn on verbose debug output of kdump scripts regarding free/used memory at

--- a/kdumpctl
+++ b/kdumpctl
@@ -341,7 +341,7 @@ parse_config()
 			dwarn "Please update $KDUMP_CONFIG_FILE to use option 'failure_action' instead."
 			_set_config failure_action "$config_val" || return 1
 			;;
-		path | core_collector | kdump_post | kdump_pre | extra_bins | extra_modules | failure_action | final_action | force_rebuild | force_no_rebuild | fence_kdump_args | fence_kdump_nodes | auto_reset_crashkernel) ;;
+		path | core_collector | kdump_post | kdump_pre | extra_bins | extra_modules | failure_action | final_action | force_rebuild | force_no_rebuild | fence_kdump_args | fence_kdump_nodes | auto_reset_crashkernel | dracut_kdump_service_timeout) ;;
 
 		net | options | link_delay | disk_timeout | debug_mem_level | blacklist)
 			derror "Deprecated kdump config option: $config_opt. Refer to kdump.conf manpage for alternatives."


### PR DESCRIPTION
The timeout time of dracut kdump service is currently 300 seconds. When i test on a physical machine with 2T memory, this time is not enough. Therefore, this  dracut_kdump_service_timeout parameter is added to support custom configuration timeout

## Summary by Sourcery

Add support for configuring the dracut kdump service start timeout via a new kdump.conf parameter and apply it to systemd’s DefaultTimeoutStartSec.

New Features:
- Introduce dracut_kdump_service_timeout in kdump.conf to allow custom kdump service start timeouts.

Enhancements:
- Propagate the custom timeout value (or fallback to default 300 s) into systemd’s kdump service configuration.

Documentation:
- Document the dracut_kdump_service_timeout parameter and its default value in the kdump.conf man page.