### PR TITLE
kdump test: output more useful info for users aware of

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1714,7 +1714,7 @@ set_kdump_test_id()
 
 	KDUMP_COMMANDLINE_APPEND+=" $_id "
 
-	if ! reload >&/dev/null; then
+	if ! reload > /dev/null; then
 		derror "Set kdump test id fail."
 		exit 1
 	fi
@@ -1931,6 +1931,7 @@ main()
 			derror "Starting kdump: [FAILED]"
 			exit 1
 		fi
+		check_vmcore_creation_status
 		;;
 	rebuild)
 		rebuild


### PR DESCRIPTION
    kdump test: output more useful info for users aware of
    
    Resolves: RHEL-96907
    Resolves: RHEL-96289
    
    This patch have no functional change for kdumpctl test, but let it
    output more info to let users know.
    
    1) Let "kdumpctl restart" to output the kdump test status:
    
        $ kdumpctl restart
        kdump: kexec: unloaded kdump kernel
        kdump: Stopping kdump: [OK]
        kdump: kexec: loaded kdump kernel
        kdump: Starting kdump: [OK]
        kdump: Notice: No vmcore creation test performed!
    
    2) Output stderr when "reload" fails, which can help user to identify
       the failing root cause:
    
        $ echo 1 > /proc/sys/kernel/kexec_load_disabled
        $ kdumpctl test
        DANGER!!! Will perform a kdump test by crashing the system, proceed? (y/N):
        kdump: Start kdump test...
        kexec_file_load(unload) failed: Operation not permitted
        kdump: kexec: failed to unload kdump kernel
        kdump: Stopping kdump: [FAILED]
        kdump: Set kdump test id fail.
    
    Signed-off-by: Tao Liu <ltao@redhat.com>
