### PR TITLE
powerpc: Set nr_cpus=16 for kdump kernel

### DIFF
--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -100,7 +100,7 @@ ppc64le)
 	update_param KDUMP_COMMANDLINE_REMOVE \
 		"hugepages hugepagesz slub_debug quiet log_buf_len swiotlb hugetlb_cma ignition.firstboot"
 	update_param KDUMP_COMMANDLINE_APPEND \
-		"irqpoll nr_cpus=1 noirqdistrib reset_devices cgroup_disable=memory numa=off udev.children-max=2 ehea.use_mcs=0 panic=10 kvm_cma_resv_ratio=0 transparent_hugepage=never novmcoredd hugetlb_cma=0"
+		"irqpoll nr_cpus=16 noirqdistrib reset_devices cgroup_disable=memory numa=off udev.children-max=2 ehea.use_mcs=0 panic=10 kvm_cma_resv_ratio=0 transparent_hugepage=never novmcoredd hugetlb_cma=0"
 	update_param FADUMP_COMMANDLINE_APPEND \
 		"nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0 hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2"
 	;;


### PR DESCRIPTION
Configure the kdump kernel with nr_cpus=16 to enable multi-threading in the makedumpfile core collector, allowing faster dump collection.

Commit d428557fc2b59 ("Use all available CPUs to collect dump") enabled the use of multi-threading for makedumpfile core collector.

There are two reasons for choosing nr_cpus=16:

 - Multiple experiments show that optimal performance is achieved when nr_cpus is between 16 and 30. The graph in commit d428557fc2b59 supports this.

 - nr_cpus=16 is already used for the fadump kernel, so using the same value for kdump to maintain consistency.