### PR TITLE
Support dumping to NVMe/TCP configured using NVMe Boot Firmware Table

### DIFF
--- a/supported-kdump-targets.txt
+++ b/supported-kdump-targets.txt
@@ -47,6 +47,8 @@ storage:
         software FCoE (bnx2fc) (Extra configuration required,
             please read "Note on FCoE" section below)
         NVMe-FC (qla2xxx, lpfc)
+        NVMe/TCP configured by NVMe Boot Firmware Table (users may need to
+            increase the crashkernel value)
 
 network:
         Hardware using kernel modules: (igb, ixgbe, ice, i40e, e1000e, igc,


### PR DESCRIPTION
The dracut nvmf module can take care of all things. It can parse ACPI
NVMe Boot Firmware Table (NBFT) tables, generate NetworkManager profiles
and discover and connect all subsystems.

Currently, the dracut kdump module will try to bring up the same network
connections as in 1st kernel. But a different set of NVMe connections
and active network interfaces will be used for the case of multipathing.
So the dracut kdump module should let dracut nvmf module do everything.

Note connecting everything and having network redundancy may require extra
memory and the default crashkernel may not work. We'll document this
issue and ask users to increase the crashkernel.