### PR TITLE
Add kdumpctl setup-crypttab subcommand

### DIFF
--- a/dracut/99kdumpbase/kexec-crypt-setup.sh
+++ b/dracut/99kdumpbase/kexec-crypt-setup.sh
@@ -1,3 +1,21 @@
 #!/bin/sh
 #
-echo true > /sys/kernel/config/crash_dm_crypt_keys/restore
+LUKS_CONFIGFS_RESTORE=/sys/kernel/config/crash_dm_crypt_keys/restore
+RESTORED=1
+MAX_WAIT_TIME=10
+wait_time=0
+
+while [ $wait_time -lt $MAX_WAIT_TIME ]; do
+    [ -e $LUKS_CONFIGFS_RESTORE ] && break
+    sleep 1
+    wait_time=$((wait_time + 1))
+done
+
+if [ $wait_time -ge $MAX_WAIT_TIME ]; then
+    echo "$LUKS_CONFIGFS_RESTORE isn't ready after ${MAX_WAIT_TIME}s, something wrong!"
+    exit 1
+fi
+
+if ! grep -q "$RESTORED" "$LUKS_CONFIGFS_RESTORE"; then
+    echo $RESTORED > $LUKS_CONFIGFS_RESTORE
+fi

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1095,7 +1095,7 @@ EOF
 }
 
 kdump_check_crypt_targets() {
-    local _luks_dev _devuuid _key_desc
+    local _devuuid _key_desc
     declare -a _luks_devs
 
     mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
@@ -1124,8 +1124,7 @@ kdump_check_crypt_targets() {
     # shellcheck disable=SC2154
     mkdir -p "$hookdir/initqueue/finished"
     CRYPTSETUP_PATH=$(command -v cryptsetup)
-    for _luks_dev in "${_luks_devs[@]}"; do
-        _devuuid=$(maj_min_to_uuid "$_luks_dev")
+    for _devuuid in "${_luks_devs[@]}"; do
         _key_desc=$LUKS_KEY_PRFIX$_devuuid
         cat << EOF >> "${initdir}/etc/udev/rules.d/70-luks-kdump.rules"
 ENV{ID_FS_UUID}=="$_devuuid", \

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1098,6 +1098,9 @@ kdump_check_crypt_targets() {
     local _devuuid _key_desc
     declare -a _luks_devs
 
+    # Currently only x86_64 is supported
+    [[ "$(uname -m)" != "x86_64" ]] && return 1
+
     mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
 
     if [[ ${#_luks_devs[@]} -lt 1 ]]; then

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -14,7 +14,7 @@ LVM_CONF="/etc/lvm/lvm.conf"
 # shellcheck disable=SC2034
 LUKS_CONFIGFS=/sys/kernel/config/crash_dm_crypt_keys
 # shellcheck disable=SC2034
-LUKS_KEY_PRFIX="systemd-cryptsetup:vk-"
+LUKS_KEY_PRFIX="kdump-cryptsetup:vk-"
 
 # Read kdump config in well formated style
 kdump_read_conf()

--- a/kdumpctl
+++ b/kdumpctl
@@ -1091,7 +1091,7 @@ _get_luks_key_by_unlock()
 
 prepare_luks()
 {
-	local _luks_dev _key_id _key_des _luks_unlock_cmd
+	local _key_id _key_des _luks_unlock_cmd
 	declare -a _luks_devs
 
 	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
@@ -1108,8 +1108,7 @@ prepare_luks()
 	# For the case of CPU/memory hotplugging, we can reuse loaded keys
 	[[ $(cat $LUKS_CONFIGFS/reuse) == 1 ]] && return 0
 
-	for _luks_dev in "${_luks_devs[@]}"; do
-		_devuuid=$(maj_min_to_uuid "$_luks_dev")
+	for _devuuid in "${_luks_devs[@]}"; do
 		_key_dir=$LUKS_CONFIGFS/$_devuuid
 		_key_des=$LUKS_KEY_PRFIX$_devuuid
 		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then

--- a/kdumpctl
+++ b/kdumpctl
@@ -1056,6 +1056,35 @@ check_final_action_config()
 	esac
 }
 
+remove_luks_vol_keys()
+{
+	local _key_line _key_id _key_desc _status=1
+
+	# Get all keys from @u keyring and process each line
+	while read -r _key_line; do
+		# Skip header lines and empty lines
+		[[ $_key_line =~ ^[0-9]+: ]] || continue
+
+		# Extract key ID (first field before colon)
+		_key_id=${_key_line%%:*}
+
+		# Extract key description (everything after "logon: " or "user: ")
+		if [[ $_key_line =~ logon:\ (.+)$ ]]; then
+			_key_desc=${BASH_REMATCH[1]}
+		else
+			continue
+		fi
+
+		# Check if key description starts with LUKS_KEY_PRFIX
+		if [[ $_key_desc == "$LUKS_KEY_PRFIX"* ]]; then
+			keyctl unlink "$_key_id"
+			_status=0
+		fi
+	done < <(keyctl list @u 2> /dev/null || true)
+
+	return $_status
+}
+
 _get_luks_key_by_unlock()
 {
 	local _devuuid=$1 _key_des=$2
@@ -1098,7 +1127,10 @@ prepare_luks()
 	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
 
 	if [[ ${#_luks_devs[@]} -lt 1 ]]; then
-		return
+		if remove_luks_vol_keys; then
+			dwarn "Encrypted device not in dump path, please drop the link-volume-key option in $CRYPTTAB_FILE"
+		fi
+		return 0
 	fi
 
 	# Currently only x86_64 is supported
@@ -1109,6 +1141,7 @@ prepare_luks()
 
 	if [[ ! -d $LUKS_CONFIGFS ]]; then
 		dwarn "$LUKS_CONFIGFS not available, please use a newer kernel or see kexec-kdump-howto.txt to make sure dumping to encrypted target will work."
+		remove_luks_vol_keys
 		return 0
 	fi
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -1079,7 +1079,8 @@ _get_luks_key_by_unlock()
 	while [ "$_attempt" -le "$_max_retries" ]; do
 		if cryptsetup open "UUID=$_devuuid" DUMMY "--link-vk-to-keyring=@u::%logon:$_key_des" --test-passphrase; then
 			ddebug "Success: LUKS device unlocked."
-			dwarn "To avoid manually running kdumpctl, ensure the link-volume-key=@u::%logon:$_key_des option is correctly set up in /etc/crypttab (see man crypttab)."
+			# For an interactive terminal, it's possible an user manually entered a passphrase
+			[ -t 0 ] && dwarn "If you typed passphrase to unlock it manually, please run 'kdumpctl setup-crypttab' (see man kdumpctl)."
 			return 0
 		fi
 		_attempt=$((_attempt + 1))
@@ -1162,6 +1163,106 @@ start()
 
 	dinfo "Starting kdump: [OK]"
 	return 0
+}
+
+# @description Updates a crypttab file to add the 'link-volume-key' option for kdump devices.
+#
+# It gets the list of kdump-related UUIDs by calling the 'get_all_kdump_crypt_dev' function.
+# The function is idempotent and performs pre-flight checks before making any modifications.
+#
+# @exitcode 0 If the update was successful or no changes were needed.
+# @exitcode 1 If there is an error (e.g. UUID mismatch).
+#
+# @stdout No output on success.
+# @stderr Progress and error messages are printed to stderr.
+CRYPTTAB_FILE=/etc/crypttab
+setup_crypttab()
+{
+	local _devuuid uuids_string temp_file
+	declare -a _luks_devs
+
+	if [[ ! -f $CRYPTTAB_FILE ]]; then
+		dinfo "$CRYPTTAB_FILE doesn't exist, skip setup"
+		return 0
+	fi
+
+	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
+	if [[ ${#_luks_devs[@]} -eq 0 ]]; then
+		dinfo "No LUKS-encrypted device found to process. Exiting."
+		return 0
+	fi
+
+	for _devuuid in "${_luks_devs[@]}"; do
+		if ! awk -v devuuid="$_devuuid" '!/^[[:space:]]*#/ && $2 == "UUID="devuuid { found=1; exit } END { exit !found }' "$CRYPTTAB_FILE"; then
+			derror "Device UUID=${_devuuid} doesn't exist."
+			return 1
+		fi
+	done
+
+	uuids_string="${_luks_devs[*]}"
+	temp_file=$(mktemp)
+
+	local status_updates
+
+	status_updates=$({
+		awk -v prefix="$LUKS_KEY_PRFIX" -v targets="$uuids_string" '
+    BEGIN {
+        split(targets, temp_arr, " ")
+        for (i in temp_arr) { target_uuids[temp_arr[i]] = 1 }
+    }
+    /^#|^$/ { print; next }
+    {
+        split($2, uuid_parts, "=")
+        current_uuid = uuid_parts[2]
+
+        if (current_uuid in target_uuids) {
+            target_option = "link-volume-key=@u::%logon:" prefix current_uuid
+
+            if (!index($0, target_option)) {
+                # If we need to modify, check if we are replacing or adding
+                if (index($0, "link-volume-key=")) {
+                    print "STATUS:REPLACED:" current_uuid > "/dev/stderr"
+                } else {
+                    print "STATUS:ADDED:" current_uuid > "/dev/stderr"
+                }
+
+                # Remove any existing, incorrect link-volume-key option
+                sub(/,?link-volume-key=[^, ]+/, "", $4)
+                sub(/^,/, "", $4)
+
+                # Add the correct option
+                if (NF < 3 || $3 == "") { $3 = "none" }
+                if ($4 == "" || $4 == "none") {
+                    $4 = target_option
+                } else {
+                    $4 = $4 "," target_option
+                }
+            }
+        }
+        print
+    }' "$CRYPTTAB_FILE" > "$temp_file"
+	} 2>&1)
+
+	if cmp -s "$CRYPTTAB_FILE" "$temp_file"; then
+		dinfo "No changes were needed. $CRYPTTAB_FILE is already up to date."
+		rm "$temp_file"
+		return 0
+	else
+		mv "$temp_file" "$CRYPTTAB_FILE"
+		dinfo "Success! $CRYPTTAB_FILE has been updated."
+
+		# Parse status updates and report on each changed UUID
+		while IFS=: read -r _ status uuid; do
+			if [[ $status == "ADDED" ]]; then
+				dinfo "   - Added link-volume-key for UUID: $uuid"
+			elif [[ $status == "REPLACED" ]]; then
+				dinfo "   - Replaced link-volume-key for UUID: $uuid"
+			fi
+		done < <(echo "$status_updates" | grep "STATUS:")
+		dinfo "If the dump target is rootfs and you call this command manually, you will need to run 'dracut -f --regenerate-all' to regenerate initramfs."
+
+		return 0
+	fi
 }
 
 reload()
@@ -2090,8 +2191,11 @@ main()
 			reset_crashkernel_for_installed_kernel "$2"
 		fi
 		;;
+	setup-crypttab)
+		setup_crypttab
+		;;
 	*)
-		dinfo $"Usage: $0 {estimate|start|stop|status|restart|reload|rebuild|reset-crashkernel|propagate|showmem|test}"
+		dinfo $"Usage: $0 {estimate|start|stop|status|restart|reload|rebuild|reset-crashkernel|propagate|showmem|test|setup-crypttab}"
 		exit 1
 		;;
 	esac

--- a/kdumpctl
+++ b/kdumpctl
@@ -1101,9 +1101,15 @@ prepare_luks()
 		return
 	fi
 
+	# Currently only x86_64 is supported
+	if [[ "$(uname -m)" != "x86_64" ]]; then
+		dwarn "Warning: Encrypted device is in dump path, which is not recommended, see kexec-kdump-howto.txt for more details."
+		return 0
+	fi
+
 	if [[ ! -d $LUKS_CONFIGFS ]]; then
-		dwarn "$LUKS_CONFIGFS not available, please use a newer kernel."
-		return 1
+		dwarn "$LUKS_CONFIGFS not available, please use a newer kernel or see kexec-kdump-howto.txt to make sure dumping to encrypted target will work."
+		return 0
 	fi
 
 	# For the case of CPU/memory hotplugging, we can reuse loaded keys
@@ -1180,6 +1186,11 @@ setup_crypttab()
 {
 	local _devuuid uuids_string temp_file
 	declare -a _luks_devs
+
+	if [[ "$(uname -m)" != "x86_64" ]]; then
+		dwarn "Currently only x86_64 supported"
+		return 0
+	fi
 
 	if [[ ! -f $CRYPTTAB_FILE ]]; then
 		dinfo "$CRYPTTAB_FILE doesn't exist, skip setup"

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -83,9 +83,11 @@ LUKS-encrypted disk volume. For more info on link-volume-key option,
 please "man crypttab".
 
 This step is optional. If kdump.service can start successfully, there is no
-need for this step. You can confirm if this step is needed by running "kdumpctl
-restart". If you need to input any passpharse to unlock the the encrypted
-volume, please run "kdumpctl setup-crypttab".
+need for this step. You can confirm if this step is needed by running
+"kdumpctl restart". If you need to input any passpharse to unlock the the
+encrypted volume, then please run "kdumpctl setup-crypttab".
+
+Note this subcommand is only helpful to x86_64 for now.
 
 .SH "SEE ALSO"
 .BR kdump.conf (5),

--- a/kdumpctl.8
+++ b/kdumpctl.8
@@ -76,6 +76,17 @@ by "kdumpctl status". Note, fadump is not supported.
 If the optional parameter [--force] is provided, there will be no confirmation
 before triggering the system crash. Dangerous though, this option is meant
 for automation testing.
+.TP
+.I setup-crypttab
+Add the 'link-volume-key' option to /etc/crypttab so vmcore can be saved to
+LUKS-encrypted disk volume. For more info on link-volume-key option,
+please "man crypttab".
+
+This step is optional. If kdump.service can start successfully, there is no
+need for this step. You can confirm if this step is needed by running "kdumpctl
+restart". If you need to input any passpharse to unlock the the encrypted
+volume, please run "kdumpctl setup-crypttab".
+
 .SH "SEE ALSO"
 .BR kdump.conf (5),
 .BR mkdumprd (8)

--- a/kexec-kdump-howto.txt
+++ b/kexec-kdump-howto.txt
@@ -882,16 +882,23 @@ or else kdump may not work as expeceted.
 Notes on encrypted dump target
 ------------------------------
 
-Currently, kdump is not working well with encrypted dump target.
-First, user have to give the password manually in capture kernel,
-so a working interactive terminal is required in the capture kernel.
+Currently, only x86_64 supports encrypted dump target. And depending on
+your setup, you may need to run "kdumpctl setup-crypttab" once in order
+for kdump.service to work on boot automatically next time. You can
+confirm if this step is needed by running "kdumpctl restart". If you have
+to input passphrase to unlock the encrypted volume, then please run 
+"kdumpctl setup-crypttab".
+
+For other architectures, kdump is not working well. First, user have
+to give the password manually in capture kernel, so a working
+interactive terminal is required in the capture kernel.
 And another major issue is that an OOM problem will occur with certain
 encryption setup. For example, the default setup for LUKS2 will use a
 memory hard key derivation function to mitigate brute force attach,
 it's impossible to reduce the memory usage for mounting the encrypted
 target. In such case, you have to either reserved enough memory for
-crash kernel according, or update your encryption setup.
-It's recommanded to use a non-encrypted target (eg. remote target)
+crash kernel accordingly, or update your encryption setup.
+It's recommended to use a non-encrypted target (eg. remote target)
 instead.
 
 Notes on device dump

--- a/spec/kdumpctl_setup_crypttab_spec.sh
+++ b/spec/kdumpctl_setup_crypttab_spec.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+Describe "kdumpctl "
+	Include ./kdumpctl
+	# dinfo is a bit complex for unit tets, simply mock it
+	dinfo() {
+		echo "$1"
+	}
+	Describe "setup_crypttab()"
+		# Set up global variables and mocks for each test
+		# shellcheck disable=SC2016 # expand expression later
+		BeforeEach 'CRYPTTAB_FILE=$(mktemp)'
+		# shellcheck disable=SC2016 # expand expression later
+		AfterEach 'rm -f "$CRYPTTAB_FILE"'
+
+		Context "when everything is correct"
+			It "adds link-volume-key to specified UUIDs"
+				# Arrange
+				get_all_kdump_crypt_dev() {
+					echo "uuid-001"
+					echo "uuid-003"
+					echo "uuid-005"
+					echo "uuid-006"
+					echo "uuid-007"
+				}
+				cat >"$CRYPTTAB_FILE" <<EOF
+luks-001 UUID=uuid-001 none discard
+luks-002 UUID=uuid-002 none discard
+# only two mandatory fields
+luks-003 UUID=uuid-003
+# two mandatory fields + one optional field
+luks-005 UUID=uuid-005 -
+# tab as delimiter
+luks-006	UUID=uuid-006
+luks-007 UUID=uuid-007 none discard,link-volume-key=TO_RE_REPLACED
+EOF
+				When call setup_crypttab
+				The status should be success
+				The output should include "Success! $CRYPTTAB_FILE has been updated."
+				The output should include "to run 'dracut -f --regenerate-all'"
+				The file "$CRYPTTAB_FILE" should be file
+				The contents of file "$CRYPTTAB_FILE" should eq \
+					"luks-001 UUID=uuid-001 none discard,link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-001
+luks-002 UUID=uuid-002 none discard
+# only two mandatory fields
+luks-003 UUID=uuid-003 none link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-003
+# two mandatory fields + one optional field
+luks-005 UUID=uuid-005 - link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-005
+# tab as delimiter
+luks-006 UUID=uuid-006 none link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-006
+luks-007 UUID=uuid-007 none discard,link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-007"
+			End
+		End
+
+		Context "with safety checks and edge cases"
+
+			It "succeeds if no LUKS device used for kdump"
+				get_all_kdump_crypt_dev() { return 0; }
+				echo "luks-001 UUID=uuid-001" >"$CRYPTTAB_FILE"
+				When call setup_crypttab
+				The status should be success
+				The output should include "No LUKS-encrypted device found to process. Exiting."
+			End
+
+			It "aborts if target UUID is not in crypttab"
+				get_all_kdump_crypt_dev() { echo "uuid-nonexistent"; }
+				echo "luks-001 UUID=uuid-001" >"$CRYPTTAB_FILE"
+				When call setup_crypttab
+				The status should be failure
+				The stderr should include "Device UUID=$(get_all_kdump_crypt_dev) doesn't exist"
+			End
+
+			It "aborts if target UUID is only in a commented-out line"
+				get_all_kdump_crypt_dev() { echo "uuid-001"; }
+				echo "#luks-001 UUID=uuid-001" >"$CRYPTTAB_FILE"
+				When call setup_crypttab
+				The status should be failure
+				The stderr should include "Device UUID=$(get_all_kdump_crypt_dev) doesn't exist"
+			End
+
+			It "succeeds with no changes if crypttab is already correct"
+				get_all_kdump_crypt_dev() { echo "uuid-001"; }
+				echo "luks-001 UUID=uuid-001 none link-volume-key=@u::%logon:${LUKS_KEY_PRFIX}uuid-001" >"$CRYPTTAB_FILE"
+				When call setup_crypttab
+				The status should be success
+				The output should include "No changes were needed."
+			End
+		End
+
+	End
+End

--- a/supported-kdump-targets.txt
+++ b/supported-kdump-targets.txt
@@ -49,7 +49,7 @@ storage:
         NVMe-FC (qla2xxx, lpfc)
         NVMe/TCP configured by NVMe Boot Firmware Table (users may need to
             increase the crashkernel value)
-        LUKS-encrypted volume
+        LUKS-encrypted volume (only x86_64 supported for now)
 
 network:
         Hardware using kernel modules: (igb, ixgbe, ice, i40e, e1000e, igc,


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-29037

Relates: https://issues.redhat.com/browse/RHEL-29039

This subcommand is to add the 'link-volume-key' option to /etc/crypttab
so the volume keys can be passed to the crash kernel to unlock
LUKS-encrypted device automatically.

This API will be also be called by kdump-anaconda-addon to set up
/etc/crypttab on installation.


Signed-off-by: Coiby Xu <coxu@redhat.com>
