### PR TITLE
refactor(gen-kdump-sysconfig): Use bash heredoc and associative arrays

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ binary_next_line   = false
 space_redirects    = true
 
 # Some scripts will only run with bash
-[{mkfadumprd,mkdumprd,kdumpctl,kdump-lib.sh}]
+[{mkfadumprd,mkdumprd,kdumpctl,kdump-lib.sh,gen-kdump-sysconfig.sh}]
 shell_variant = bash


### PR DESCRIPTION
The script gen-kdump-sysconfig.sh is refactored to use bash heredoc instead of regex to generate kdump sysconfig file. Bash associative arrays are also used to manage architecture-specific values. This change improves readability and maintainability by centralizing the configuration for each architecture. For example, we could have avoided the mistake made by commit ddb0bab1 ("sysconfig: disable kfence in kdump kernel").

The default values are now stored under the 'default' key within the associative arrays, simplifying the logic for handling unknown or unspecified architectures.


Assisted-by: Google Gemini