### PR TITLE
kdump test: 2 improvements

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -2188,6 +2188,8 @@ main()
 			derror "Starting kdump: [FAILED]"
 			exit 1
 		fi
+		check_vmcore_creation_status
+		exit 0
 		;;
 	stop)
 		if ! stop; then
@@ -2224,6 +2226,7 @@ main()
 			exit 1
 		fi
 		check_vmcore_creation_status
+		exit 0
 		;;
 	rebuild)
 		rebuild


### PR DESCRIPTION
This patchset include 2 patches:

1) kdump test: reword the misleading test result. This one have no functional change, but a reword to fix a semantics misleading issue.

2)  kdump test: Let "kdumpctl start" to output the kdump test status. This one will add kdump test status check into start(), so users can know if kdump tested as early.

I haven't add "resolves" keyword to patch 1, because the original jira issue, aka RHEL-92256, is closed. Because the original jira issue required additional feature which I think is not doable, and this patch however, only relieved it. 

