### PR TITLE
Add persisent device if FIPS is enabled

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -433,8 +433,9 @@ if ! is_fadump_capable; then
 	# to /sysroot beforehand.
 	if [[ $(cat /proc/sys/crypto/fips_enabled 2> /dev/null) == 1 ]]; then
 		_boot_source=$(findmnt -n -o SOURCE --target /boot)
+		_disk_persistent=$(get_persistent_dev "$_boot_source")
 		if mountpoint -q /boot; then
-			dracut_args+=(--add-device "$_boot_source")
+			dracut_args+=(--add-device "$_disk_persistent")
 		else
 			add_mount "$_boot_source"
 		fi


### PR DESCRIPTION
mkdumprd has a code to add a disk to kdump initramfs, in case FIPS is enabled and /boot is on a separate partition. This code used to work, since dracut was not force checking that added disk is in fact available. Since dracut commit c79fc8f dracut in fact checks for added device, and since disk name could have been changed between live system and kdump initramfs, kdump can fail. To resolve this problem add disk by UUID, not by disk name.