### PR TITLE
Add timeout for nfs mount within kdumpctl & mkdumprd

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -2065,7 +2065,7 @@ set_vmcore_creation_status()
 fetch_status()
 {
 	local _test_id="$1" _mnt
-	local _status
+	local _status _timeout_cmd=""
 
 	is_raw_dump_target && return 2
 
@@ -2073,9 +2073,13 @@ fetch_status()
 
 	if is_nfs_dump_target || is_local_target; then
 		_mnt=$(get_mntpoint_from_target "${OPT[_target]}")
+		if is_nfs_dump_target; then
+			_timeout_cmd="timeout --preserve-status 5m"
+		fi
+
 		if [[ -z $_mnt ]] || ! is_mounted "$_mnt"; then
 			mkdir -p "$TMPMNT"
-			mount "${OPT[_target]}" "$TMPMNT" -t "${OPT[_fstype]}" -o defaults ||
+			$_timeout_cmd mount "${OPT[_target]}" "$TMPMNT" -t "${OPT[_fstype]}" -o defaults ||
 				{
 					dwarn "Failed to mount ${OPT[_target]}" && return 2
 				}

--- a/mkdumprd
+++ b/mkdumprd
@@ -208,7 +208,7 @@ mount_failure()
 	msg="$msg for kdump preflight check."
 
 	if [[ $_fstype == "nfs" ]]; then
-		msg="$msg Please make sure nfs-utils has been installed."
+		msg="$msg Please make sure nfs-utils has been installed, and nfs server is accessible."
 	fi
 
 	perror_exit "$msg"
@@ -217,7 +217,7 @@ mount_failure()
 check_user_configured_target()
 {
 	local _target=$1 _cfg_fs_type=$2 _mounted
-	local _mnt _opt _fstype
+	local _mnt _opt _fstype _timeout_cmd=""
 
 	_mnt=$(get_mntpoint_from_target "$_target")
 	_opt=$(get_mntopt_from_target "$_target")
@@ -235,12 +235,16 @@ check_user_configured_target()
 		_fstype="$_cfg_fs_type"
 	fi
 
+	if [[ $_fstype == "nfs"* ]]; then
+		_timeout_cmd="timeout --preserve-status 10m"
+	fi
+
 	# For noauto mount, mount it inplace with default value.
 	# Else use the temporary target directory
 	if [[ -n $_mnt ]]; then
 		if ! is_mounted "$_mnt"; then
 			if [[ $_opt == *",noauto"* ]]; then
-				mount "$_mnt" || mount_failure "$_target" "$_mnt" "$_fstype"
+				$_timeout_cmd mount "$_mnt" || mount_failure "$_target" "$_mnt" "$_fstype"
 				_mounted=$_mnt
 			else
 				perror_exit "Dump target \"$_target\" is neither mounted nor configured as \"noauto\""
@@ -249,7 +253,7 @@ check_user_configured_target()
 	else
 		_mnt=$MKDUMPRD_TMPMNT
 		mkdir -p "$_mnt"
-		mount "$_target" "$_mnt" -t "$_fstype" -o defaults || mount_failure "$_target" "" "$_fstype"
+		$_timeout_cmd mount "$_target" "$_mnt" -t "$_fstype" -o defaults || mount_failure "$_target" "" "$_fstype"
 		_mounted=$_mnt
 	fi
 


### PR DESCRIPTION
In kdumpctl and mkdumprd, for nfs dump target, cmd mount will be used to mount nfs dump target to local directory. However there is no time limit for mount, and it may take a long time for mount to finish, no matter success or fail, when network connection is unstable.

E.g we can emulate the package loss using the following command:

    $ tc qdisc add dev tun0 root handle 1: prio
    $ tc qdisc add dev tun0 parent 1:3 handle 30: netem delay 2000ms 1000ms loss 80%
    $ tc filter add dev tun0 protocol ip parent 1:0 prio 3 u32 match ip dst <nfs_server_ip> flowid 1:3

This will emulate 80% network package loss to <nfs_server_ip>, then we invoke nfs mount:

    $ time mount -t nfs <nfs_server_ip>:<nfs_dir> /mnt

    real	354m56.200s
    user	0m0.003s
    sys		0m0.013s

    $ mount | grep nfs
    <nfs_server_ip>:<nfs_dir> on /mnt type nfs4 (...)

As we can see, though mount succeeded finally, it took near 6h to finish. The long time waiting makes no sense and should be ended as early, so user can check network issues and retry.

This issue also noticed in QE testing, because for beaker test tasks, if one task doesn't finish within a specific time period, the task will be killed and fail. We'd better set a timeout limit for nfs mount, in order to prevent it from connecting to nfs server timelessly.

This patch will set timeout duration as 5min for kdumpctl, and 10min for mkdumprd, as I think they are enough for normal cases as well as bail out as early if network do encounter problems.