### PR TITLE
kdump.sh: Skip num-threads when -E option presents

### DIFF
--- a/dracut/99kdumpbase/kdump.sh
+++ b/dracut/99kdumpbase/kdump.sh
@@ -116,7 +116,13 @@ get_kdump_confs() {
             fi
             THREADS=$(nproc)
             if [ "$THREADS" -gt 1 ]; then
-                CORE_COLLECTOR="$CORE_COLLECTOR --num-threads=$THREADS"
+                case "$CORE_COLLECTOR" in
+                    *-F* | *-E*) ;;
+
+                    *)
+                        CORE_COLLECTOR="$CORE_COLLECTOR --num-threads=$THREADS"
+                        ;;
+                esac
             fi
             ;;
     esac


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-75537

Configure "makedumpfile -E -d 31" in kdump.conf, and panic the system, kdump will fail with the error as:

[   41.891856] kdump.sh[724]: --num-threads cannot used with ELF format.
[   41.897104] kdump.sh[724]: Commandline parameter is invalid.
[   41.897290] kdump.sh[724]: Try `makedumpfile --help' for more information.
[   41.897435] kdump.sh[724]: makedumpfile Failed.
[   41.898804] kdump[726]:
saving vmcore failed, exitcode:1

Skip --num-threads when -E option is given