### PR TITLE
kdumpctl: check force[_no]_rebuild when do estimate

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1532,8 +1532,9 @@ do_estimate()
 	local kernel_size mod_size initrd_size baseline_size runtime_size reserved_size estimated_size recommended_size _cryptsetup_overhead
 	local size_mb=$((1024 * 1024))
 
-	setup_initrd
-	is_system_modified
+	parse_config || return 1
+	setup_initrd || return 1
+	need_initrd_rebuild
 	case "$?" in
 	0)
 		# Nothing to do


### PR DESCRIPTION
Use need_initrd_rebuild() instead of is_system_modified to check if the initrd needs to be rebuilt during do_estimate, it checks whether force_rebuild or force_no_rebuild is used.