### PR TITLE
Add systemd service for servicelog_notify

### DIFF
--- a/kdump-migrate-notify.service
+++ b/kdump-migrate-notify.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Register kdump migration notification
+After=kdump.service
+ConditionPathExists=/usr/lib/kdump/kdump-migrate-action.sh
+ConditionPathExists=/usr/bin/servicelog_notify
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/servicelog_notify --add --command=/usr/lib/kdump/kdump-migrate-action.sh --match='refcode="#MIGRATE" and serviceable=0' --type=EVENT --method=pairs_stdin
+ExecStop=/usr/bin/servicelog_notify --remove --command=/usr/lib/kdump/kdump-migrate-action.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This introduces a new systemd service for servicelog_notify to ensure proper setup during the actual boot process (e.g., for bootc environments).

This commit only provides the unit file and has no immediate operational impact. Downstream packaging must configure the appropriate systemd preset and post-install script to enable it.

Unlike the previous method, which only executed during kdump-utils installation or upgrades, via a systemd service will run servicelog_notify on every system boot.