### PR TITLE
kdump-lib: Retrieve xDUMP_COMMANDLINE_APPEND from sysconfig

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1014,7 +1014,10 @@ fadump_bootargs_append()
 
 		# shellcheck disable=SC2153
 		if output=$({
-			echo "${FADUMP_COMMANDLINE_APPEND}" > "$FADUMP_APPEND_ARGS_SYS_NODE"
+			local _fadump_append
+
+			_fadump_append=$(get_dump_commandline fadump) || exit
+			echo "$_fadump_append" > "$FADUMP_APPEND_ARGS_SYS_NODE"
 		} 2>&1); then
 			output=$(cat "$FADUMP_APPEND_ARGS_SYS_NODE")
 			dinfo "fadump: additional parameters for capture kernel: '$output'"


### PR DESCRIPTION
The current references to KDUMP_COMMANDLINE_APPEND or FADUMP_COMMANDLINE_APPEND return nothing because these variables are dynamically generated by gen-sysconfig-kdump.sh.

To retrieve these variables, introduce a function
get_dump_commandline(). It is the caller's responsibility to ensure '/etc/sysconfig/kdump' exists; otherwise, get_dump_commandline() will output an error message.