### PR TITLE
kdump-lib: check kdump service state when validating fadump load

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -2209,6 +2209,7 @@ main()
 {
 	# Determine if the dump mode is kdump or fadump
 	determine_dump_mode
+	local rc
 
 	case "$1" in
 	start)
@@ -2228,7 +2229,13 @@ main()
 	status)
 		EXIT_CODE=0
 		is_kernel_loaded "$DEFAULT_DUMP_MODE"
-		case "$?" in
+		rc=$?
+
+		if [ "$rc" -eq 0 ] && [ "$DEFAULT_DUMP_MODE" = "fadump" ]; then
+			systemctl is-active --quiet kdump.service || rc=1
+		fi
+
+		case "$rc" in
 		0)
 			dinfo "Kdump is operational"
 			EXIT_CODE=0


### PR DESCRIPTION
Currently, kdumpctl status reports kdump as operational even when the kdump service is in a failed state for fadump.

root> kdumpctl status
kdump: Dump mode is fadump
kdump: Kdump is operational

root> systemctl status kdump
× kdump.service - Crash recovery kernel arming
     Loaded: loaded (/usr/lib/systemd/system/kdump.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Tue 2026-01-20 02:52:59 CST; 12s ago
<snip...>
cp: error writing '/boot/initramfs-6.12.0-180.el10.ppc64le.img.tmp': No space left on device dracut[F]: Creation of /boot/initramfs-6.12.0-180.el10.ppc64le.img.tmp failed <snip...>

This happens because the kernel registers fadump during early boot [1]. Even if the kdump service later fails to start due to a failure while updating the initrd with the fadump component, /sys/kernel/fadump/registered still remains set to 1. As a result, kdump is reported as operational, even though it is not.

Fix this by checking the kdump service state when validating the fadump load.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=607451ce0aa9bdff590db4d087173edba6d7a29d

Reported-by: Shirisha G <shirisha@linux.ibm.com>