### PR TITLE
tests: Make kdump/crash-sysrq-c skip vmcore checking

### DIFF
--- a/kernel-tests-plans/main.fmf
+++ b/kernel-tests-plans/main.fmf
@@ -21,6 +21,9 @@ adjust:
         package: "$KDUMP_UTILS_RPM"
         where: client
 
+environment:
+    PANIC_VMCORE_CHECK: false
+
 execute:
     how: tmt
     exit-first: true


### PR DESCRIPTION
The 2nd part of kdump/crash-sysrq-c test will check for the existence of dumped vmcore by default. But it only works for local dumping. For NFS/SSH dumping, PANIC_VMCORE_CHECK=false will be needed to skip it.

Since we already use analyse-crash-cmd/simple_check, apply PANIC_VMCORE_CHECK=false to all test plans.

Note current NFS/SSH test plans don't fail because currently kdump/crash-sysrq-c skips the 2nd part of test but this will be fixed by https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/merge_requests/4550