### PR TITLE
kdumpctl: Let reset-crashkernel returns 0 for ostree if it succeeds

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1873,8 +1873,9 @@ reset_crashkernel()
 		_new_ck=$(kdump_get_arch_recommend_crashkernel kdump)
 		if _update_kernel_cmdline "" crashkernel "$_old_ck" "$_new_ck"; then
 			[[ $_reboot == yes ]] && systemctl reboot
+			return 0
 		fi
-		return
+		return 1
 	fi
 
 	# If kernel-path not specified, either


### PR DESCRIPTION
Currently, when running "kdumpctl reset-crashkernel" on ostree systems, the exit code is 1 even the command succeeds,
    # kdumpctl reset-crashkernel
    Staging deployment... done
    Changes queued for next boot. Run "systemctl reboot" to start a reboot
    # echo $?
    1

This happens because the status of last command
"[[ $_reboot == yes ]] && systemctl reboot" is returned.

Return 0 when updating the crashkernel kernel parameter succeeds and return 1 otherwise.

Note the kdump/config-default-crashkernel currently doesn't fail on CoreOS because of https://github.com/teemtee/tmt/issues/4718.