### PR TITLE
kdumpctl: Deprecate raw dump targets

### DIFF
--- a/gen-kdump-conf.sh
+++ b/gen-kdump-conf.sh
@@ -27,9 +27,9 @@ generate()
 #             overwritten to the default crahskernel value.
 #
 # raw <partition>
-#           - Will dd /proc/vmcore into <partition>.
-#             Use persistent device names for partition devices,
-#             such as /dev/vg/<devname>.
+#           - The 'raw' dump target is deprecated and will be removed in a future
+#             release. Please migrate to a filesystem-based dump target (e.g., ext4,
+#             xfs, nfs, or ssh).
 #
 # nfs <nfs mount>
 #           - Will mount nfs to <mnt>, and copy /proc/vmcore to
@@ -178,7 +178,6 @@ generate()
 #             (this option is mandatory to enable fence_kdump).
 #
 
-#raw /dev/vg/lv_kdump
 #ext4 /dev/vg/lv_kdump
 #ext4 LABEL=/boot
 #ext4 UUID=03138356-5e61-4ab3-b58e-27507ac41937

--- a/kdump.conf.5
+++ b/kdump.conf.5
@@ -3,7 +3,7 @@
 .SH NAME
 kdump.conf \- configuration file for kdump kernel.
 
-.SH DESCRIPTION 
+.SH DESCRIPTION
 
 kdump.conf is a configuration file for the kdump kernel crash
 collection service.
@@ -16,7 +16,7 @@ effect, restart the kdump service to rebuild the initrd.
 For most configurations, you can simply review the examples provided
 in the stock /etc/kdump.conf.
 
-.B NOTE: 
+.B NOTE:
 For filesystem dumps the dump target must be mounted before building
 kdump initramfs.
 
@@ -53,13 +53,15 @@ Also see kdumpctl(8).
 .B raw <partition>
 .RS
 Will dd /proc/vmcore into <partition>.  Use persistent device names for
-partition devices, such as /dev/vg/<devname>.
+partition devices, such as /dev/vg/<devname>. The "raw" dump target is
+deprecated and will be removed in a future release. Please migrate to a
+filesystem-based dump target (e.g., ext4, xfs, nfs, or ssh).
 .RE
 
 .B nfs <nfs mount>
 .RS
 Will mount nfs to <mnt>, and copy /proc/vmcore to <mnt>/<path>/%HOST-%DATE/,
-supports DNS. Note that a fqdn should be used as the server name in the 
+supports DNS. Note that a fqdn should be used as the server name in the
 mount point.
 .RE
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -350,6 +350,7 @@ parse_config()
 			fi
 			;;
 		raw)
+			dwarn "The 'raw' dump target is deprecated and will be removed in a future release. Please migrate to a filesystem-based dump target (e.g., ext4, xfs, nfs, or ssh)."
 			if [[ -d "/proc/device-tree/ibm,opal/dump" ]]; then
 				dwarn "Won't capture opalcore when 'raw' dump target is used."
 			fi

--- a/kexec-kdump-howto.txt
+++ b/kexec-kdump-howto.txt
@@ -451,6 +451,8 @@ onto partition /dev/vg/lv_kdump. Restart the kdump service via
 initrd. Dump target should be persistent device name, such as lvm or device
 mapper canonical name.
 
+Raw targets will be deprecated in a future version.
+
 2) Dedicated file system
 
 Similar to raw partition dumping, you can format a partition with the file
@@ -901,7 +903,7 @@ Currently, only x86_64 supports encrypted dump target. And depending on
 your setup, you may need to run "kdumpctl setup-crypttab" once in order
 for kdump.service to work on boot automatically next time. You can
 confirm if this step is needed by running "kdumpctl restart". If you have
-to input passphrase to unlock the encrypted volume, then please run 
+to input passphrase to unlock the encrypted volume, then please run
 "kdumpctl setup-crypttab".
 
 For other architectures, kdump is not working well. First, user have


### PR DESCRIPTION
The raw dump target (using dd to a partition) is being phased out in favor of filesystem-based targets. This patch adds deprecation warnings to the documentation and runtime scripts to alert users that support will be removed in a future release.

Due to editor settings, this patch also removes some trailing spaces.

Resolves: #141

Assisted-by: Google Gemini