### PR TITLE
kdumpctl: Add get-default-crashkernel command to help list

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -2310,7 +2310,7 @@ main()
 		setup_crypttab
 		;;
 	*)
-		dinfo $"Usage: $0 {estimate|start|stop|status|restart|reload|rebuild|reset-crashkernel|propagate|showmem|test|setup-crypttab}"
+		dinfo $"Usage: $0 {estimate|start|stop|status|restart|reload|rebuild|reset-crashkernel|propagate|showmem|test|setup-crypttab|get-default-crashkernel}"
 		exit 1
 		;;
 	esac


### PR DESCRIPTION
get-default-crashkernel is shown in documentation but not in `kdumpctl --help`, include this command in the help.

Resolves: RHEL-145107