### PR TITLE
tests: Test against image-mode Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,6 +17,7 @@ jobs:
     dist_git_branches: [fedora-all]
   - job: copr_build
     trigger: pull_request
+    manual_trigger: true
     targets:
       - fedora-42-x86_64
       - fedora-rawhide-x86_64
@@ -24,6 +25,7 @@ jobs:
     packages: [kdump-utils]
   - job: tests
     trigger: pull_request
+    manual_trigger: true
     targets:
       - fedora-42-x86_64
       - fedora-rawhide-x86_64

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,37 +1,27 @@
+---
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
-
 specfile_path: kdump-utils.spec
-
 # add or remove files that should be synced
 files_to_sync:
-    - kdump-utils.spec
-    - .packit.yaml
-
+  - kdump-utils.spec
+  - .packit.yaml
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: kdump-utils
 # downstream (Fedora) RPM package name
 downstream_package_name: kdump-utils
-
 upstream_tag_template: v{version}
-
-
 jobs:
   - job: propose_downstream
     trigger: release
-    dist_git_branches:
-      - fedora-all
-
-
+    dist_git_branches: [fedora-all]
   - job: copr_build
     trigger: pull_request
     targets:
       - fedora-42-x86_64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
-    packages:
-      - kdump-utils
-
+    packages: [kdump-utils]
   - job: tests
     trigger: pull_request
     targets:
@@ -56,13 +46,9 @@ jobs:
             # report cloud costs: https://docs.testing-farm.io/Testing%20Farm/0.1/services.html#_changing_the_team_name
               tags:
                 BusinessUnit: sst_kernel_debug_sst
-
   - job: koji_build
     trigger: commit
-    dist_git_branches:
-      - fedora-all
-
+    dist_git_branches: [fedora-all]
   - job: bodhi_update
     trigger: commit
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: [fedora-all]

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,6 +30,7 @@ jobs:
       - fedora-42-x86_64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
+    identifier: package-mode
     fmf_path: kernel-tests-plans
     use_internal_tf: true
     tf_extra_params:
@@ -48,6 +49,27 @@ jobs:
             # report cloud costs: https://docs.testing-farm.io/Testing%20Farm/0.1/services.html#_changing_the_team_name
               tags:
                 BusinessUnit: sst_kernel_debug_sst
+  - job: tests
+    trigger: pull_request
+    targets:
+      fedora-44:
+        distros: ["fedora-44-image-mode"]
+    skip_build: true
+    identifier: image-mode
+    fmf_path: kernel-tests-plans
+    # Currently only public testing farm supports image-mode Fedora
+    use_internal_tf: false
+    tf_extra_params:
+      test:
+        tmt:
+          name: local
+      environments:
+        - settings:
+            provisioning:
+            # report cloud costs: https://docs.testing-farm.io/Testing%20Farm/0.1/services.html#_changing_the_team_name
+              tags:
+                BusinessUnit: sst_kernel_debug_sst
+
   - job: koji_build
     trigger: commit
     dist_git_branches: [fedora-all]


### PR DESCRIPTION
tests: Test against image-mode Fedora

Currently only public testing farm instance supports image-mode Fedora.
And to run mulitple tests, an identifier is needed [1].

[1] https://packit.dev/docs/configuration/upstream/tests