### PR TITLE
kdumpctl: Use only first match in _find_kernel_path_by_release()

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1698,7 +1698,7 @@ _find_kernel_path_by_release()
 
 	# Insert '/' before '+' to cope with grep's EREs
 	_release=${_release//+/\\+}
-	_grubby_kernel_str=$(grubby --info ALL | grep -E "^kernel=.*$_release(/\w+)?\"$")
+	_grubby_kernel_str=$(grubby --info ALL | grep -m 1 -E "^kernel=.*$_release(/\w+)?\"$")
 	_kernel_path=$(_filter_grubby_kernel_str "$_grubby_kernel_str")
 	if [[ -z $_kernel_path ]]; then
 		ddebug "kernel $_release doesn't exist"


### PR DESCRIPTION
Running 'grubby --info ALL' (or even for a specific kernel version) can return multiple entries for the same kernel version/release (usually with different append parameters, initrds, etc), so when grepping for a specific kernel version/release, we need to use only the first match.

This results in kdumpctl failing with the error message (from grubby):
  "The param $KERNELPATH\n$KERNELPATH is incorrect"
replacing $KERNELPATH with the actual vmlinuz path.

This bug is hidden when /boot is a separate partition, because the grubby script has regex (`"/${param##*/}" = "${bls_linux[$i]}"`) which strips all duplicate lines and base path, and successfully matches "/vmlinuz-*".

This is reproducable by simply moving the /boot contents into a normal dir in the rootfs (instead of separate fs).