### PR TITLE
kdump/fadump: exclude 90-vpdupdate.rules from initramfs on ppc64le

### DIFF
--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -784,6 +784,15 @@ remove_sysctl_conf() {
     rm -rf "${initdir}/usr/lib/sysctl.d"
 }
 
+# Removes unwanted udev rules from the initramfs image.
+remove_udev_rules() {
+    # Exclude 90-vpdupdate.rules on ppc64le as VPD updates are not needed
+    # in the capture kernel.
+    if [[ "$(uname -m)" == "ppc64le" ]]; then
+        rm -f "${initdir}/etc/udev/rules.d/90-vpdupdate.rules"
+    fi
+}
+
 kdump_iscsi_get_rec_val() {
 
     local result
@@ -1170,6 +1179,7 @@ install() {
     kdump_module_init
     kdump_install_conf
     remove_sysctl_conf
+    remove_udev_rules
 
     if is_ssh_dump_target; then
         kdump_install_random_seed


### PR DESCRIPTION
The 90-vpdupdate.rules udev rule monitors hardware device events (SCSI, NVMe, etc.) and signals VPD (Vital Product Data) updates by touching /run/run.vpdupdate. This triggers the vpdupdate service to collect and refresh hardware inventory data on IBM POWER systems.

In the kdump/fadump capture kernel environment, /bin/touch is not available in the minimal initramfs and /run is mounted read-only, causing udev worker failures for every matching device event during capture kernel boot:

[    0.797948] (udev-worker)[387]: serial8250:0.3: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.
[    0.799011] (udev-worker)[388]: ttyS0: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.
[    0.799526] (udev-worker)[409]: ttyS1: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.
[    0.801795] (udev-worker)[388]: breakpoint: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.
[    0.803810] (udev-worker)[415]: ttyS2: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.
[    0.805560] (udev-worker)[392]: cpu: Process '/bin/touch /run/run.vpdupdate' failed with exit code 1.

Since the capture kernel's sole purpose is to collect the crash dump and reboot, hardware VPD updates are unnecessary. Exclude the rule from the kdump/fadump initramfs on ppc64le to eliminate the udev worker errors.
