### PR TITLE
A few bug fixes for kdump utils tests

### DIFF
--- a/tests/plans/ssh.fmf
+++ b/tests/plans/ssh.fmf
@@ -10,6 +10,12 @@ discover:
      - /setup/default_crashkernel
     where:
       - client
+  - name: Set up ssh server
+    how: fmf
+    test:
+     - /setup/network_client/ssh
+    where:
+      - server
   - name: Set up ssh client
     how: fmf
     test:

--- a/tests/setup/network_client/test.sh
+++ b/tests/setup/network_client/test.sh
@@ -75,14 +75,22 @@ EOF
 elif [[ $REMOTE_TYPE == SSH ]]; then
     TMT_TEST_PLAN_ROOT=${TMT_PLAN_DATA%data}
     SERVER_SSH_KEY=${TMT_TEST_PLAN_ROOT}/provision/server/id_ecdsa
-    if test -f "$SERVER_SSH_KEY"; then
-        rlRun "ssh-keyscan -H $SERVER > /root/.ssh/known_hosts"
-        rlRun "ssh root@$SERVER -i $SERVER_SSH_KEY 'mkdir /var/crash'"
-        rlRun "echo ssh root@$SERVER > /etc/kdump.conf"
-        rlRun "echo sshkey $SERVER_SSH_KEY >> /etc/kdump.conf"
-        rlRun "echo core_collector makedumpfile -l --message-level 7 -d 31 -F >> /etc/kdump.conf"
+    CLIENT_SSH_PUBKEY=${TMT_TEST_PLAN_ROOT}/provision/client/id_ecdsa.pub
+    if [[ -f "$SERVER_SSH_KEY" && -f "$CLIENT_SSH_PUBKEY" ]]; then
+        if [[ ${MY_IP} == ${SERVER_IP} ]]; then
+            rlRun "cat $CLIENT_SSH_PUBKEY >> /root/.ssh/authorized_keys"
+        else
+            rlRun "ssh-keyscan -H $SERVER > /root/.ssh/known_hosts"
+            rlRun "ssh root@$SERVER -i $SERVER_SSH_KEY 'mkdir -p /var/crash'"
+            rlRun "echo ssh root@$SERVER > /etc/kdump.conf"
+            rlRun "echo sshkey $SERVER_SSH_KEY >> /etc/kdump.conf"
+            rlRun "echo core_collector makedumpfile -l --message-level 7 -d 31 -F >> /etc/kdump.conf"
+        fi
     else
-        rlDie "Server SSH Key not found, something wrong"
+        [[ -f "$SERVER_SSH_KEY" ]] || \
+            rlDie "Server SSH Key not found, something wrong"
+        [[ -f "$CLIENT_SSH_PUBKEY" ]] || \
+            rlDie "Client SSH Pubkey not found, something wrong"
     fi
 fi
 rlPhaseEnd

--- a/tests/setup/nfs_server/test.sh
+++ b/tests/setup/nfs_server/test.sh
@@ -10,6 +10,7 @@ rlRun "dnf -y install nfs-utils"
 rlRun "mkdir -p /var/tmp/nfsshare/var/crash"
 rlRun "echo '/var/tmp/nfsshare 192.168.0.0/16(rw,no_root_squash)' >> /etc/exports"
 rlRun "systemctl enable --now rpcbind nfs-server"
+rlRun "systemctl restart nfs-server"
 rlPhaseEnd
 
 rlJournalEnd

--- a/tests/setup/ovs_network/test.sh
+++ b/tests/setup/ovs_network/test.sh
@@ -5,7 +5,7 @@ ovs_configure_script=/usr/local/bin/configure-ovs.sh
 extract_configure-ovs-script() {
     local _script_url
 
-    _script_url=https://github.com/openshift/machine-config-operator/raw/refs/heads/master/templates/common/_base/files/configure-ovs-network.yaml
+    _script_url=https://github.com/openshift/machine-config-operator/raw/refs/heads/main/templates/common/_base/files/configure-ovs-network.yaml
 
     if curl -sL $_script_url | grep -A2000 '#!/bin/bash' > "$ovs_configure_script"; then
         chmod +x "$ovs_configure_script"

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -13,7 +13,7 @@ if ! rpm_path=$(./tools/build-rpm.sh "$fedora_version"); then
 	exit 1
 fi
 
-tmt_run_env=(--environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" --environment RESOURCE_URL=https://gitlab.cee.redhat.com/kernel-qe/kernel/-/raw/master/kdump/internal/internal_resources.sh --environment AUTO_CONFIG=pek)
+tmt_run_env=(--environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" --environment RESOURCE_URL=https://gitlab.cee.redhat.com/kernel-qe/kernel/-/raw/master/kdump/internal/internal_resources.sh --environment AUTO_CONFIG=bos)
 
 tmt_context=(--context distro="fedora-${fedora_version}")
 cd tests && tmt "${tmt_context[@]}" run "${tmt_run_env[@]}" -a provision -h virtual -i fedora:"$fedora_version" plans --name lvm2_thinp


### PR DESCRIPTION
This patchset contains 4 patches:

4 tests: Update the default ssh/nfs dump server
3 tests: Copy ssh client's pubkey to ssh server
2 tests: Restart the nfs-server service after "systemctl enable --now"
1 tests: Update the url of ovs configure script

1 & 4 are fixes on outdated info.
2 & 3 are fixes on bugs I have encountered.

To run the local tests:
$ tools/build-rpm.sh 44
/root/kdump-utils/x86_64/kdump-utils-1.0.62-1.fc44.x86_64.rpm
$ cd tests
$ tmt run --environment KDUMP_UTILS_RPM="/root/kdump-utils/x86_64/kdump-utils-1.0.62-1.fc44.x86_64.rpm" -a