### PR TITLE
tests: fedora-42 is outdated target

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,7 +49,7 @@ jobs:
         - variables:
             # use internal NFS/SSH server to avoid creating another VM as NFS/SSH server
             RESOURCE_URL: https://gitlab.cee.redhat.com/kernel-qe/kernel/-/raw/master/kdump/internal/internal_resources.sh
-            AUTO_CONFIG: auto
+            AUTO_CONFIG: bos
             SUBMITTER: rhkdump_kdump_utils_packit
         - settings:
             provisioning:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,7 +26,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-42-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
     packages:
@@ -35,7 +35,7 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-42-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
     fmf_path: kernel-tests-plans


### PR DESCRIPTION
Let's use fedora-latest-stable as target.