### PR TITLE
99-kdump.conf: Add clevis-pin-file to omit_dracutmodules

### DIFF
--- a/99-kdump.conf
+++ b/99-kdump.conf
@@ -1,5 +1,5 @@
 dracutmodules=''
 add_dracutmodules=' kdumpbase '
 omit_dracutmodules=' hwdb rdma plymouth resume ifcfg earlykdump '
-omit_dracutmodules+=' clevis clevis-pin-null clevis-pin-tang clevis-pin-sss clevis-pin-tpm2 '
+omit_dracutmodules+=' clevis clevis-pin-null clevis-pin-tang clevis-pin-sss clevis-pin-tpm2 clevis-pin-file '
 omit_drivers+=' nouveau amdgpu '


### PR DESCRIPTION
Omit the clevis-pin-file module to avoid dracut warning during kdump initramfs rebuild.

 dracut[E]: Module 'clevis-pin-file' depends on module 'clevis',
 which can't be installed